### PR TITLE
fix variable name bug due to rename

### DIFF
--- a/dptb/postprocess/NEGF.py
+++ b/dptb/postprocess/NEGF.py
@@ -217,14 +217,14 @@ class NEGF(object):
                     for ll in leads:
                         if ll.startswith("lead"):
                             getattr(self.deviceprop, ll).self_energy(
-                                e=e, 
+                                energy=e, 
                                 kpoint=k, 
                                 eta_lead=self.jdata["eta_lead"],
                                 method=self.jdata["sgf_solver"]
                                 )
                             
                     self.deviceprop.cal_green_function(
-                        e=e,
+                        energy=e,
                         kpoint=k, 
                         eta_device=self.jdata["eta_device"], 
                         block_tridiagonal=self.block_tridiagonal


### PR DESCRIPTION
 fix functions' variable name bug in dptb/postprocess/NEGF.py due to rename.
It doesn't change dptb code.