### PR TITLE
add fixed length on iter checkpoint

### DIFF
--- a/dptb/plugins/plugins.py
+++ b/dptb/plugins/plugins.py
@@ -15,6 +15,7 @@ class Saver(Plugin):
         super(Saver, self).__init__(interval)
         self.best_loss = 1e7
         self.best_quene = []
+        self.latest_quene = []
 
     def register(self, trainer, checkpoint_path):
         self.checkpoint_path = checkpoint_path
@@ -24,8 +25,15 @@ class Saver(Plugin):
         # suffix = "_b"+"%.3f"%self.trainer.common_options["bond_cutoff"]+"_c"+"%.3f"%self.trainer.onsite_options["skfunction"]["sk_cutoff"]+"_w"+\
         #         "%.3f"%self.trainer.model_options["skfunction"]["sk_decay_w"]
         suffix = ".iter{}".format(self.trainer.iter+1)
+        name = self.trainer.model.name+suffix
+        self.latest_quene.append(name)
+        if len(self.latest_quene) >= 5:
+            delete_name = self.latest_quene.pop(0)
+            delete_path = os.path.join(self.checkpoint_path, delete_name+".pth")
+            os.remove(delete_path)
+        
         self._save(
-            name=self.trainer.model.name+suffix,
+            name=name,
             model=self.trainer.model,
             model_options=self.trainer.model.model_options,
             common_options=self.trainer.common_options,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ torch-runstats = "0.2.0"
 torch_scatter = "2.1.2"
 torch_geometric = ">=2.4.0"
 opt-einsum = "3.3.0"
+h5py = "3.7.0"
 
 
 [tool.poetry.group.dev.dependencies]
@@ -46,6 +47,7 @@ torch-runstats = "0.2.0"
 torch_scatter = "2.1.2"
 torch_geometric = ">=2.4.0"
 opt-einsum = "3.3.0"
+h5py = "3.7.0"
 
 
 [tool.poetry.group.3Dfermi]


### PR DESCRIPTION
add a fixed-length queue for saving the latest checkpoint.
The latest checkpoint is recorded according to the training iteration, which is nnsk/dptb.iterxxx.pth.

After this update, this iteration checkpoint will only preserve the latest 4. 