### PR TITLE
fix(embeding): The numerical instability in construct the descriptors for high symmetry structures. 

### DIFF
--- a/dptb/nn/embedding/se2.py
+++ b/dptb/nn/embedding/se2.py
@@ -110,8 +110,8 @@ class SE2Aggregation(Aggregation):
         _type_
             _description_
         """
-        direct_vec = x[:, -3:]
-        x = x[:,:-3].unsqueeze(-1) * direct_vec.unsqueeze(1) # [N_env, D, 3]
+        direct_vec = x[:, -4:]
+        x = x[:,:-4].unsqueeze(-1) * direct_vec.unsqueeze(1) # [N_env, D, 3]
         return self.reduce(x, index, reduce="mean", dim=0) # [N_atom, D, 3] following the orders of atom index.
 
 
@@ -127,7 +127,7 @@ class _SE2Descriptor(MessagePassing):
             dtype: Union[str, torch.dtype] = torch.float32, 
             device: Union[str, torch.device] = torch.device("cpu"), **kwargs):
         
-        super(_SE2Descriptor, self).__init__(aggr=aggr, **kwargs)
+        super(_SE2Descriptor, self).__init__(aggr=aggr, **kwargs, flow="target_to_source")
 
         if isinstance(device, str):
             device = torch.device(device)
@@ -173,7 +173,7 @@ class _SE2Descriptor(MessagePassing):
     def message(self, env_vectors, env_attr):
         rij = env_vectors.norm(dim=-1, keepdim=True)
         snorm = self.smooth(rij, self.rs, self.rc)
-        env_vectors = snorm * env_vectors / rij
+        env_vectors = torch.cat([snorm, snorm * env_vectors / rij], dim=-1)
         return torch.cat([self.embedding_net(torch.cat([snorm, env_attr], dim=-1)), env_vectors], dim=-1) # [N_env, D_emb + 3]
 
     def update(self, aggr_out):


### PR DESCRIPTION
In high symmtry structures, there is chance that the mirror symmetry will cancel out the product  G \dot R; if R only contains (x,y,z) information.  there will be numerical instability in this case for the standardization the descriptor vector xx, by seting xx=xx/xx.norm. 

What we do here, is to update SE2Aggregation class in se2.py to and add radial info into env matrix. use  the the R being (1/rij, x,y,z) as 4 elements as it is in deepmd. in this case, for high-symmetry strucutre, the 1/rij term can not be canceled out since it is always >=0.  

Besides, we alos update _SE2Descriptor class in se2.py to set the flow parameter to "target_to_source". though previous the source_to_target is also correct. but use target_to_source is more natural  by defination.

