### PR TITLE
update(pyproject.toml): To allow write out a _version.py file that contrains the current version information

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [tool.poetry]
 name = "dptb"
-version = "2.0.1"
+version = "0.0.0"
 license = "LGPL-3.0"
 description = "A deep learning package for emperical tight-binding approach with first-principle accuracy."
 authors = ["Q. Gu <guqq@pku.edu.cn>", "Z. Zhanghao <zhouyinzhanghao@gmail.com>"]
 readme = "README.md"
-repository = "https://github.com/deepmodeling/DeePTB"
+repository = "https://github.com/deepmodeling/DeePTB.git"
 
 [tool.poetry.dependencies]
 python = ">=3.8"
@@ -78,13 +78,23 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 
 [tool.poetry-dynamic-versioning]
-enable = false
+enable = true
 vcs = "git"
 strict = true
 format-jinja = """
-{%- if distance == 0 -%}
-        {{ serialize_pep440(base) }}
-{%- else -%}
-        {{serialize_pep440(bump_version(base, index=1), dev=timestamp)}}
-{%- endif -%}
+    {%- if distance == 0 -%}
+        {{ serialize_pep440(base, stage, revision) }}
+    {%- elif revision is not none -%}
+        {{ serialize_pep440(base, stage, revision + 1, dev=distance, metadata=[commit]) }}
+    {%- else -%}
+        {{ serialize_pep440(bump_version(base), stage, revision, dev=distance, metadata=[commit]) }}
+    {%- endif -%}
+"""
+
+[tool.poetry-dynamic-versioning.files."dptb/_version.py"]
+persistent-substitution = true
+initial-content = """
+  # These version placeholders will be replaced later during substitution.
+  __version__ = "0.0.0"
+  __version_tuple__ = (0, 0, 0)
 """


### PR DESCRIPTION
This is achieved by the following method:
1. modify format jinja: format-jinja = """
    {%- if distance == 0 -%}
        {{ serialize_pep440(base, stage, revision) }}
    {%- elif revision is not none -%}
        {{ serialize_pep440(base, stage, revision + 1, dev=distance, metadata=[commit]) }}
    {%- else -%}
        {{ serialize_pep440(bump_version(base), stage, revision, dev=distance, metadata=[commit]) }}
    {%- endif -%}
"""
Which have 3 cases: 1. if the commit version is consistent with the tag, then use the tag 2. If the revision (小版本) is not 0, and commit have some history, then new version will be x.x.x+1+devxxxxxxxx. 3. if the revision is 0, them the stage 中版本，will increase by 1 and the dev string will be added.

2. add [tool.poetry-dynamic-versioning.files.] tool to write out files _version.py
[tool.poetry-dynamic-versioning.files."dptb/_version.py"]
persistent-substitution = true
initial-content = """
  # These version placeholders will be replaced later during substitution.
  __version__ = "0.0.0"
  __version_tuple__ = (0, 0, 0)
"""