### PR TITLE
feat(loss): add new loss options to control number bands to exclude in in dft bands.

### DIFF
--- a/dptb/utils/argcheck.py
+++ b/dptb/utils/argcheck.py
@@ -714,6 +714,8 @@ def loss_options():
         Argument("diff_on", bool, optional=True, default=False, doc="Whether to use random differences in loss function. Default: False"),
         Argument("eout_weight", float, optional=True, default=0.01, doc="The weight of eigenvalue out of range. Default: 0.01"),
         Argument("diff_weight", float, optional=True, default=0.01, doc="The weight of eigenvalue difference. Default: 0.01"),
+        Argument("diff_valence", [dict,None], optional=True, default=None, doc="set the difference of the number of valence electrons in DFT and TB. eg {'A':6,'B':7}, Default: None, which means no difference"),
+        Argument("spin_deg", int, optional=True, default=2, doc="The spin degeneracy of band structure. Default: 2"),
     ]
 
     skints = [

--- a/dptb/utils/config_sk.py
+++ b/dptb/utils/config_sk.py
@@ -30,6 +30,8 @@ TrainFullConfigSK={
         "loss_options": {
             "train": {
                 "method": "eigvals",
+                "diff_valence":None,
+                "spin_deg":2,
                 "diff_on": False,
                 "eout_weight": 0.01,
                 "diff_weight": 0.01


### PR DESCRIPTION
1. Update EigLoss class in loss.py to include new parameters diff_valence and spin_deg

2. Update loss_options function in argcheck.py to include new parameters diff_valence and spin_deg

3. Update TrainFullConfigSK dictionary in config_sk.py to include new parameters diff_valence and spin_deg