### PR TITLE
Fix unit test: compare the bond index related tensors the order is not important, remove the check for order.  

### DIFF
--- a/dptb/tests/test_atomicdata_rmaxdict.py
+++ b/dptb/tests/test_atomicdata_rmaxdict.py
@@ -5,6 +5,7 @@ import torch
 from dptb.utils.constants import atomic_num_dict, atomic_num_dict_r
 import os
 from pathlib import Path
+from dptb.tests.tstools import compare_tensors_as_sets
 
 rootdir = os.path.join(Path(os.path.abspath(__file__)).parent, "data")
 
@@ -17,10 +18,9 @@ def test_rmax_float():
     atomic_options['r_max'] = 2.6
 
     data = AtomicData.from_ase(atoms, **atomic_options)
-    assert (data.edge_index == torch.tensor([[0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1],
-        [0, 1, 0, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1]])).all()
-    
-    assert (data.edge_cell_shift == torch.tensor([[-1.,  0.,  0.],
+    expected_edge_index = torch.tensor([[0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1],
+        [0, 1, 0, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1]])
+    expected_edge_cell_shift = torch.tensor([[-1.,  0.,  0.],
         [-1.,  0.,  0.],
         [ 0.,  1.,  0.],
         [ 0.,  1.,  0.],
@@ -37,7 +37,10 @@ def test_rmax_float():
         [-0., -0., -0.],
         [-1., -1., -0.],
         [-0.,  1., -0.],
-        [ 1., -0., -0.]])).all()
+        [ 1., -0., -0.]])
+    exp_val = torch.cat((expected_edge_index.T, expected_edge_cell_shift), axis=1)
+    tar_val = torch.cat((data.edge_index.T, data.edge_cell_shift), axis=1)
+    assert compare_tensors_as_sets(exp_val, tar_val)
 
 def test_rmax_dict_eq():
     strfile = os.path.join(rootdir, "hBN", "hBN.vasp")
@@ -46,10 +49,10 @@ def test_rmax_dict_eq():
     atomic_options['pbc'] = True
     atomic_options['r_max']  = {'B': 2.6, 'N': 2.6}
     data = AtomicData.from_ase(atoms, **atomic_options)
-    assert (data.edge_index == torch.tensor([[0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1],
-        [0, 1, 0, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1]])).all()
-    
-    assert (data.edge_cell_shift == torch.tensor([[-1.,  0.,  0.],
+
+    expected_edge_index = torch.tensor([[0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1],
+        [0, 1, 0, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1]])
+    expected_edge_cell_shift =  torch.tensor([[-1.,  0.,  0.],
         [-1.,  0.,  0.],
         [ 0.,  1.,  0.],
         [ 0.,  1.,  0.],
@@ -66,8 +69,11 @@ def test_rmax_dict_eq():
         [-0., -0., -0.],
         [-1., -1., -0.],
         [-0.,  1., -0.],
-        [ 1., -0., -0.]])).all()
-    
+        [ 1., -0., -0.]])
+    exp_val = torch.cat((expected_edge_index.T, expected_edge_cell_shift), axis=1)
+    tar_val = torch.cat((data.edge_index.T, data.edge_cell_shift), axis=1)
+    assert compare_tensors_as_sets(exp_val, tar_val)
+
 def test_rmax_dict_neq():
     strfile = os.path.join(rootdir, "hBN", "hBN.vasp")
     atoms = read(strfile)
@@ -75,10 +81,9 @@ def test_rmax_dict_neq():
     atomic_options['pbc'] = True
     atomic_options['r_max']  = {'B':1.5,'N':2.6}
     data = AtomicData.from_ase(atoms, **atomic_options)
-    assert (data.edge_index == torch.tensor([[0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1],
-        [0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0]])).all()
-    
-    assert (data.edge_cell_shift == torch.tensor([[-1.,  0.,  0.],
+    expected_edge_index = torch.tensor([[0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1],
+        [0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0]])
+    expected_edge_cell_shift = torch.tensor([[-1.,  0.,  0.],
         [-1.,  0.,  0.],
         [ 0.,  1.,  0.],
         [ 0.,  1.,  0.],
@@ -89,4 +94,8 @@ def test_rmax_dict_neq():
         [-0., -1., -0.],
         [-0., -1., -0.],
         [-1., -1., -0.],
-        [-0., -0., -0.]])).all()
+        [-0., -0., -0.]])
+    exp_val = torch.cat((expected_edge_index.T, expected_edge_cell_shift), axis=1)
+    tar_val = torch.cat((data.edge_index.T, data.edge_cell_shift), axis=1)
+    assert compare_tensors_as_sets(exp_val, tar_val)
+    

--- a/dptb/tests/test_default_dataset.py
+++ b/dptb/tests/test_default_dataset.py
@@ -8,6 +8,7 @@ import numpy as np
 from pathlib import Path
 from ase.io.trajectory import Trajectory
 import torch as th
+from dptb.tests.tstools import compare_tensors_as_sets
 
 rootdir = os.path.join(Path(os.path.abspath(__file__)).parent, "data/test_sktb/dataset")
 
@@ -88,7 +89,8 @@ class TestDefaultDatasetSKTB:
         assert (np.abs(atomic_data.pos.numpy() - self.strase[0].positions) < 1e-6).all()
         assert (np.abs(atomic_data.cell.numpy() - self.strase[0].cell) < 1e-6).all()
 
-        assert th.abs(atomic_data.edge_index - expected_edge_index).sum() < 1e-8
+        assert compare_tensors_as_sets(atomic_data.edge_index.T, expected_edge_index.T) 
+        # assert th.abs(atomic_data.edge_index - expected_edge_index).sum() < 1e-8
         assert atomic_data.node_features.shape == (2, 1)
         assert not "node_attrs" in data[0]
         assert not "batch" in data[0]

--- a/dptb/tests/test_dftbsk.py
+++ b/dptb/tests/test_dftbsk.py
@@ -8,7 +8,7 @@ from dptb.data.build import build_dataset
 from pathlib import Path
 from dptb.data import AtomicDataset, DataLoader, AtomicDataDict, AtomicData
 import numpy as np
-
+from dptb.tests.tstools import compare_tensors_as_sets_float
 
 rootdir = os.path.join(Path(os.path.abspath(__file__)).parent, "data")
 
@@ -86,7 +86,8 @@ class TestDFTBSK:
         [-1.1053317, -1.4127309,  1.7213905, -0.3220515],
         [-1.1053317, -1.4127309,  1.7213905, -0.3220515]])
 
-        assert torch.allclose(data[AtomicDataDict.EDGE_FEATURES_KEY], expected_edge_feature)
+        assert compare_tensors_as_sets_float(data[AtomicDataDict.EDGE_FEATURES_KEY], expected_edge_feature, precision=5)
+        # assert torch.allclose(data[AtomicDataDict.EDGE_FEATURES_KEY], expected_edge_feature)
 
         expected_edge_overlap = torch.tensor([[ 0.0115951, -0.0208762, -0.0355638,  0.0046229],
         [ 0.2665880,  0.3365866,  0.3249941, -0.1442579],
@@ -107,7 +108,8 @@ class TestDFTBSK:
         [ 0.0399277,  0.0585683, -0.0838758,  0.0126881],
         [ 0.0399277,  0.0585683, -0.0838758,  0.0126881]])
 
-        assert torch.allclose(data[AtomicDataDict.EDGE_OVERLAP_KEY], expected_edge_overlap)
+        assert compare_tensors_as_sets_float(data[AtomicDataDict.EDGE_OVERLAP_KEY], expected_edge_overlap, precision=5)
+        # assert torch.allclose(data[AtomicDataDict.EDGE_OVERLAP_KEY], expected_edge_overlap)
 
         assert AtomicDataDict.NODE_SOC_SWITCH_KEY in data
         assert not data[AtomicDataDict.NODE_SOC_SWITCH_KEY].all()

--- a/dptb/tests/test_nnsk.py
+++ b/dptb/tests/test_nnsk.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from dptb.data import AtomicDataset, DataLoader, AtomicDataDict, AtomicData
 import numpy as np
 from dptb.utils.constants import atomic_num_dict_r
+from dptb.tests.tstools import compare_tensors_as_sets_float
 
 rootdir = os.path.join(Path(os.path.abspath(__file__)).parent, "data")
 
@@ -121,7 +122,8 @@ class TestNNSK:
         [ 0.0109460149, -0.0026458376, -0.0233188029,  0.0033660505],
         [ 0.0109460149, -0.0026458376, -0.0233188029,  0.0033660505]])
 
-        assert torch.allclose(data[AtomicDataDict.EDGE_FEATURES_KEY], expected_hopskint, atol=1e-10)
+        assert compare_tensors_as_sets_float(data[AtomicDataDict.EDGE_FEATURES_KEY], expected_hopskint, precision=6)
+        # assert torch.allclose(data[AtomicDataDict.EDGE_FEATURES_KEY], expected_hopskint, atol=1e-10)
 
     def test_nnsk_uniform_varTang96(self):
         model_options = self.model_options
@@ -195,7 +197,8 @@ class TestNNSK:
         [-0.0043444759,  0.0260002706, -0.0492796339,  0.0716556087],
         [-0.0043444759,  0.0260002706, -0.0492796339,  0.0716556087]])
 
-        assert torch.allclose(data[AtomicDataDict.EDGE_FEATURES_KEY], expected_hopskint, atol=1e-10)
+        assert compare_tensors_as_sets_float(data[AtomicDataDict.EDGE_FEATURES_KEY], expected_hopskint, precision=6)
+        # assert torch.allclose(data[AtomicDataDict.EDGE_FEATURES_KEY], expected_hopskint, atol=1e-10)
 
     def test_nnsk_onsite_strain(self):
         model_options = self.model_options

--- a/dptb/tests/tstools.py
+++ b/dptb/tests/tstools.py
@@ -1,0 +1,91 @@
+import torch
+import numpy as np
+from collections import Counter
+
+def compare_tensors_as_sets(tensor1, tensor2):
+    """
+    Compare whether two tensors contain the same rows, regardless of order.
+    Args:
+    tensor1 (torch.Tensor or array-like): The first tensor with shape (n, m).
+    tensor2 (torch.Tensor or array-like): The second tensor with shape (n, m).
+    Returns:
+    bool: True if the two tensors contain the same set of rows, otherwise False.
+    """
+    if not isinstance(tensor1, torch.Tensor):
+        tensor1 = torch.tensor(tensor1)
+    # elif has grad:
+    elif tensor1.requires_grad:
+        tensor1 = tensor1.detach()
+    if not isinstance(tensor2, torch.Tensor):
+        tensor2 = torch.tensor(tensor2)
+    elif tensor2.requires_grad:
+        tensor2 = tensor2.detach()
+
+    if tensor1.dim() == 1:
+        tensor1 = tensor1.unsqueeze(1)
+    elif tensor1.dim() > 2:
+        raise ValueError('The first tensor must have rank <=2')
+    if tensor2.dim() == 1:
+        tensor2 = tensor2.unsqueeze(1)
+    elif tensor2.dim() > 2:
+        raise ValueError('The second tensor must have rank <=2')
+    
+    if tensor1.shape!= tensor2.shape:
+        return False
+    
+    set1 = {tuple(row.tolist()) for row in tensor1}
+    set2 = {tuple(row.tolist()) for row in tensor2}
+    
+    return set1 == set2
+
+def compare_tensors_as_sets_float(tensor1, tensor2, precision=6):
+    """
+    Compare whether two tensors contain the same rows, regardless of order.
+    Args:
+    tensor1 (torch.Tensor or array-like): The first tensor with shape (n, m).
+    tensor2 (torch.Tensor or array-like): The second tensor with shape (n, m).
+    Returns:
+    bool: True if the two tensors contain the same set of rows, otherwise False.
+    """
+    # Ensure that the input is a tensor
+    if not isinstance(tensor1, torch.Tensor):
+        tensor1 = torch.tensor(tensor1)
+    elif tensor1.requires_grad:
+        tensor1 = tensor1.detach()
+    if not isinstance(tensor2, torch.Tensor):
+        tensor2 = torch.tensor(tensor2)
+    elif tensor2.requires_grad:
+        tensor2 = tensor2.detach()
+    # Ensure that the input is rank 2
+    if tensor1.dim() == 1:
+        tensor1 = tensor1.unsqueeze(1)
+    elif tensor1.dim() > 2:
+        raise ValueError('The first tensor must have rank <=2')
+    if tensor2.dim() == 1:
+        tensor2 = tensor2.unsqueeze(1)
+    elif tensor2.dim() > 2:
+        raise ValueError('The second tensor must have rank <=2')
+    
+    if tensor1.shape != tensor2.shape:
+        return False
+    
+    # transform tensors to NumPy arrays and round to the specified precision
+    arr1 = np.round(tensor1.numpy(), precision)
+    arr2 = np.round(tensor2.numpy(), precision)
+    
+    # use a structured array for more efficient comparison
+    dtype = [(f'f{i}', 'float64') for i in range(arr1.shape[1])]
+    
+    # Convert arrays to structured arrays
+    structured_arr1 = np.array([tuple(row) for row in arr1], dtype=dtype)
+    structured_arr2 = np.array([tuple(row) for row in arr2], dtype=dtype)
+    
+    # sort and compare unique values
+    unique1 = np.unique(structured_arr1, return_counts=True)
+    unique2 = np.unique(structured_arr2, return_counts=True)
+    
+    # compare the unique values and their counts
+    
+    return (unique1[0].shape == unique2[0].shape and 
+            np.all(unique1[0] == unique2[0]) and 
+            np.all(unique1[1] == unique2[1]))


### PR DESCRIPTION
add compare_tensors_as_sets_float, remove the comparison of order dependence in  band index-related tensors