### PR TITLE
feat: add jit for so2 tensor product and E3ElementLinear

### DIFF
--- a/dptb/nn/tensor_product.py
+++ b/dptb/nn/tensor_product.py
@@ -1,228 +1,292 @@
-from e3nn.o3 import xyz_to_angles, Irreps
+import os
 import math
 import torch
 import torch.nn as nn
 from torch.nn import Linear
-import os
+from typing import List, Optional, Tuple
+from e3nn.o3 import xyz_to_angles, Irreps
+from e3nn.util.jit import compile_mode
 
 
+_Jd_file = os.path.join(os.path.dirname(__file__), "Jd.pt")
+if os.path.exists(_Jd_file):
+    _Jd = torch.load(_Jd_file)
+else:
+    print(f"Warning: Jd.pt not found at {_Jd_file}. Wigner D functions will fail.")
+    _Jd = []
 
-_Jd = torch.load(os.path.join(os.path.dirname(__file__), "Jd.pt"), weights_only=False)
 
-def wigner_D(l, alpha, beta, gamma):
+def wigner_D(l: int, alpha: torch.Tensor, beta: torch.Tensor, gamma: torch.Tensor) -> torch.Tensor:
+    if not _Jd:
+        raise RuntimeError("Jd.pt was not loaded. Cannot compute Wigner D matrices.")
     if not l < len(_Jd):
         raise NotImplementedError(
             f"wigner D maximum l implemented is {len(_Jd) - 1}, send us an email to ask for more"
         )
-
     alpha, beta, gamma = torch.broadcast_tensors(alpha, beta, gamma)
     J = _Jd[l].to(dtype=alpha.dtype, device=alpha.device)
-    Xa = _z_rot_mat(alpha, l)
-    Xb = _z_rot_mat(beta, l)
-    Xc = _z_rot_mat(gamma, l)
+    Xa = _z_rot(alpha, l)
+    Xb = _z_rot(beta, l)
+    Xc = _z_rot(gamma, l)
     return Xa @ J @ Xb @ J @ Xc
 
 
-def _z_rot_mat(angle, l):
-    shape, device, dtype = angle.shape, angle.device, angle.dtype
-    M = angle.new_zeros((*shape, 2 * l + 1, 2 * l + 1))
-    inds = torch.arange(0, 2 * l + 1, 1, device=device)
-    reversed_inds = torch.arange(2 * l, -1, -1, device=device)
-    frequencies = torch.arange(l, -l - 1, -1, dtype=dtype, device=device)
-    M[..., inds, reversed_inds] = torch.sin(frequencies * angle[..., None])
-    M[..., inds, inds] = torch.cos(frequencies * angle[..., None])
-    return M
+@torch.jit.script
+def _z_rot(angle: torch.Tensor, l: int) -> torch.Tensor:
+    freqs = torch.arange(l, -l - 1, -1, dtype=angle.dtype, device=angle.device)
+    diag_elements = torch.cos(freqs * angle.unsqueeze(-1))
+    anti_diag_elements = torch.sin(freqs * angle.unsqueeze(-1))
+    diag_matrix = torch.diag_embed(diag_elements)
+    anti_diag_matrix = torch.flip(torch.diag_embed(anti_diag_elements), dims=[-1])
+    return diag_matrix + anti_diag_matrix
 
-class SO2_Linear(torch.nn.Module):
-    """
-    SO(2) Conv: Perform an SO(2) convolution on features corresponding to +- m
 
-    Args:
-        m (int):                    Order of the spherical harmonic coefficients
-        sphere_channels (int):      Number of spherical channels
-        m_output_channels (int):    Number of output channels used during the SO(2) conv
-        lmax_list (list:int):       List of degrees (l) for each resolution
-        mmax_list (list:int):       List of orders (m) for each resolution
-    """
+@compile_mode("script")
+class SO2_Linear(nn.Module):
+    in_dim: int
+    out_dim: int
+    in_num_irreps: int
+    out_num_irreps: int
+    has_radial: bool
+
     def __init__(
-        self,
-        irreps_in,
-        irreps_out,
-        radial_emb: bool = False,
-        latent_dim: int = None,
-        radial_channels: list = None,
-        extra_m0_outsize: int = 0,
+            self,
+            irreps_in: Irreps,
+            irreps_out: Irreps,
+            radial_emb: bool = False,
+            latent_dim: int = 0,
+            radial_channels: Optional[List[int]] = None,
+            extra_m0_outsize: int = 0,
     ):
-        super(SO2_Linear, self).__init__()
-        
+        super().__init__()
+        if not _Jd:
+            raise RuntimeError("Jd.pt was not loaded. SO2_Linear cannot be initialized.")
+        self.Jd: List[torch.Tensor] = _Jd
 
-        self.irreps_in = irreps_in.simplify()
-        self.irreps_out = (Irreps(f"{extra_m0_outsize}x0e") + irreps_out).simplify()
-        self.radial_emb = radial_emb
-        self.latent_dim = latent_dim
-        self.m_linear = nn.ModuleList()
-        self.fc_m0 = Linear(self.irreps_in.num_irreps, self.irreps_out.num_irreps, bias=True)
-        for m in range(1, self.irreps_out.lmax + 1):
-            self.m_linear.append(SO2_m_Linear(m, self.irreps_in, self.irreps_out))
-        
-        # generate m mask
-        self.m_in_mask = torch.zeros(self.irreps_in.lmax+1, self.irreps_in.dim, dtype=torch.bool)
-        self.m_out_mask = torch.zeros(self.irreps_in.lmax+1, self.irreps_out.dim, dtype=torch.bool)
-        
-        if self.irreps_in.dim <= self.irreps_out.dim:
-            front = True
-            self.m_in_num = [0] * (self.irreps_in.lmax+1)
+        irreps_in_s = irreps_in.simplify()
+        irreps_out_s = (Irreps(f"{extra_m0_outsize}x0e") + irreps_out).simplify()
+
+        self.irreps_out: Irreps = irreps_out_s
+        self.in_dim = irreps_in_s.dim
+        self.out_dim = irreps_out_s.dim
+        self.in_num_irreps = irreps_in_s.num_irreps
+        self.out_num_irreps = irreps_out_s.num_irreps
+        self.has_radial = radial_emb
+
+        if radial_channels is None:
+            radial_channels = []
+
+        in_offsets_list: List[int] = []
+        in_mul_list: List[int] = []
+        in_l_list: List[int] = []
+        current_offset = 0
+        for mul, (l, p_val) in irreps_in_s:
+            in_offsets_list.append(current_offset)
+            in_mul_list.append(mul)
+            in_l_list.append(l)
+            current_offset += mul * (2 * l + 1)
+        in_offsets_list.append(current_offset)
+        self.register_buffer('in_offsets', torch.tensor(in_offsets_list, dtype=torch.long))
+        self.register_buffer('in_mul', torch.tensor(in_mul_list, dtype=torch.long))
+        self.register_buffer('in_l', torch.tensor(in_l_list, dtype=torch.long))
+
+        out_offsets_list: List[int] = []
+        out_mul_list: List[int] = []
+        out_l_list: List[int] = []
+        current_offset = 0
+        for mul, (l, p_val) in irreps_out_s:
+            out_offsets_list.append(current_offset)
+            out_mul_list.append(mul)
+            out_l_list.append(l)
+            current_offset += mul * (2 * l + 1)
+        out_offsets_list.append(current_offset)
+        self.register_buffer('out_offsets', torch.tensor(out_offsets_list, dtype=torch.long))
+        self.register_buffer('out_mul', torch.tensor(out_mul_list, dtype=torch.long))
+        self.register_buffer('out_l', torch.tensor(out_l_list, dtype=torch.long))
+
+        m_in_mask = torch.zeros(irreps_in_s.lmax + 1, self.in_dim, dtype=torch.bool)
+        cnt_list = [0] * (irreps_in_s.lmax + 1)
+
+        current_offset_for_mask = 0
+        for i in range(len(irreps_in_s)):
+            mul, (l, p_val) = irreps_in_s[i]
+            for k_mul in range(mul):
+                base_idx = current_offset_for_mask + k_mul * (2 * l + 1)
+                for m_val in range(l + 1):
+                    if m_val == 0:
+                        m_in_mask[m_val, base_idx + l] = True
+                        cnt_list[m_val] += 1
+                    else:
+                        m_in_mask[m_val, base_idx + l + m_val] = True
+                        m_in_mask[m_val, base_idx + l - m_val] = True
+                        cnt_list[m_val] += 1
+            current_offset_for_mask += mul * (2 * l + 1)
+        self.register_buffer('m_in_mask', m_in_mask)
+        self.register_buffer('cnt', torch.tensor(cnt_list, dtype=torch.long))
+
+        m_idx = torch.cat([torch.tensor([0], dtype=torch.long), torch.cumsum(self.cnt, dim=0)])
+        self.register_buffer('m_idx', m_idx)
+
+        m_out_mask = torch.zeros(irreps_out_s.lmax + 1, self.out_dim, dtype=torch.bool)
+        current_offset_for_mask = 0
+        for i in range(len(irreps_out_s)):
+            mul, (l, p_val) = irreps_out_s[i]
+            for k_mul in range(mul):
+                base_idx = current_offset_for_mask + k_mul * (2 * l + 1)
+                for m_val in range(l + 1):
+                    if m_val <= irreps_in_s.lmax:
+                        if m_val == 0:
+                            m_out_mask[m_val, base_idx + l] = True
+                        else:
+                            m_out_mask[m_val, base_idx + l + m_val] = True
+                            m_out_mask[m_val, base_idx + l - m_val] = True
+            current_offset_for_mask += mul * (2 * l + 1)
+        self.register_buffer('m_out_mask', m_out_mask)
+
+        self.fc0 = Linear(self.in_num_irreps, self.out_num_irreps, bias=True)
+
+        self.m_linears = nn.ModuleList([
+            SO2_m_Linear(m, irreps_in_s, irreps_out_s) for m in range(1, irreps_out_s.lmax + 1)
+        ])
+
+        if self.has_radial:
+            if latent_dim <= 0:
+                raise ValueError("latent_dim must be > 0 if radial_emb is True")
+            layers_list: List[nn.Module] = []
+            current_ch_radial = latent_dim
+            all_radial_net_channels = radial_channels + [int(m_idx[-1].item())]
+            for i, next_ch_radial in enumerate(all_radial_net_channels):
+                layers_list.append(Linear(current_ch_radial, next_ch_radial, bias=True))
+                current_ch_radial = next_ch_radial
+                if i < len(all_radial_net_channels) - 1:
+                    layers_list.append(nn.LayerNorm(next_ch_radial))
+                    layers_list.append(nn.SiLU())
+            self.radial: nn.Module = nn.Sequential(*layers_list)
         else:
-            front = False
-            self.m_in_num = [0] * (self.irreps_out.lmax+1)
-    
-            
-        offset = 0
-        for mul, (l, p) in self.irreps_in:
-            start_id = offset + torch.LongTensor(list(range(mul))) * (2 * l + 1)
-            for m in range(l+1):
-                self.m_in_mask[m, start_id+l+m] = True
-                self.m_in_mask[m, start_id+l-m] = True
-                if front:
-                    self.m_in_num[m] += mul
-            offset += mul * (2 * l + 1)
+            self.radial: nn.Module = nn.Identity()  # Explicitly type self.radial here for clarity
 
-        # assert sum(self.m_in_num) == self.irreps_in.dim
-            
-        offset = 0
-        for mul, (l, p) in self.irreps_out:
-            start_id = offset + torch.LongTensor(list(range(mul))) * (2 * l + 1)
-            for m in range(l+1):
-                if m <= self.irreps_in.lmax:
-                    self.m_out_mask[m, start_id+l+m] = True
-                    self.m_out_mask[m, start_id+l-m] = True
-                    if not front:
-                        self.m_in_num[m] += mul
-            offset += mul * (2 * l + 1)
+    def _wigner(self, l: int, alpha: torch.Tensor, beta: torch.Tensor, gamma: torch.Tensor) -> torch.Tensor:
+        J = self.Jd[l].to(dtype=alpha.dtype, device=alpha.device)
+        return _z_rot(alpha, l) @ J @ _z_rot(beta, l) @ J @ _z_rot(gamma, l)
 
-        self.m_in_index = [0] + list(torch.cumsum(torch.tensor(self.m_in_num), dim=0))
-        if radial_emb:
-            self.radial_emb = RadialFunction([latent_dim]+radial_channels+[self.m_in_index[-1]])
-        self.front = front
+    def forward(
+            self,
+            x: torch.Tensor,
+            R: torch.Tensor,
+            latents: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        n = x.size(0)
+        alpha, beta = xyz_to_angles(R[:, [1, 2, 0]])
+        gamma = torch.zeros_like(alpha)
 
-    def forward(self, x, R, latents=None):
-        n, _ = x.shape
+        # MODIFIED PART FOR w CALCULATION
+        w: Optional[torch.Tensor] = None
+        if self.has_radial:
+            if latents is None:
+                raise RuntimeError("`latents` must be provided and be a Tensor when `radial_emb=True`")
+            w = self.radial(latents)
+            # END OF MODIFIED PART
 
-        if self.radial_emb:
-            weights = self.radial_emb(latents)
-        
-        x_ = torch.zeros(n, self.irreps_in.dim, dtype=x.dtype, device=x.device)
-        for (mul, (l,p)), slice in zip(self.irreps_in, self.irreps_in.slices()):
-            if l > 0:
-                angle = xyz_to_angles(R[:,[1,2,0]]) # (tensor(N), tensor(N))
-                # The roataion matrix is SO3 rotation, therefore Irreps(l,1), is used here.
-                rot_mat_L = wigner_D(l, angle[0], angle[1], torch.zeros_like(angle[0]))
-                x_[:, slice] = torch.einsum('nji,nmj->nmi', rot_mat_L, x[:, slice].reshape(n,mul,-1)).reshape(n,-1)
+        x_rot = x.clone()
+        for i in range(len(self.in_mul)):
+            start = int(self.in_offsets[i].item())
+            end = int(self.in_offsets[i + 1].item())
+            mul = int(self.in_mul[i].item())
+            l_val = int(self.in_l[i].item())
 
-        out = torch.zeros(n, self.irreps_out.dim, dtype=x.dtype, device=x.device)
-        for m in range(self.irreps_out.lmax+1):
-            radial_weight = weights[:, self.m_in_index[m]:self.m_in_index[m+1]].unsqueeze(1) if self.radial_emb else 1.
-            if m == 0:
-                if self.front and self.radial_emb:
-                    out[:, self.m_out_mask[m]] += self.fc_m0(x_[:, self.m_in_mask[m]] * radial_weight.squeeze(1))
-                elif self.radial_emb:
-                    out[:, self.m_out_mask[m]] += self.fc_m0(x_[:, self.m_in_mask[m]]) * radial_weight.squeeze(1)
-                else:
-                    out[:, self.m_out_mask[m]] += self.fc_m0(x_[:, self.m_in_mask[m]])
-            else:
-                if self.front and self.radial_emb:
-                    out[:, self.m_out_mask[m]] += self.m_linear[m-1](x_[:, self.m_in_mask[m]].reshape(n, 2, -1)*radial_weight).reshape(n, -1)
-                elif self.radial_emb:
-                    out[:, self.m_out_mask[m]] += (self.m_linear[m-1](x_[:, self.m_in_mask[m]].reshape(n, 2, -1))*radial_weight).reshape(n, -1)
-                else:
-                    out[:, self.m_out_mask[m]] += self.m_linear[m-1](x_[:, self.m_in_mask[m]].reshape(n, 2, -1)).reshape(n, -1)
-                    
-        out.contiguous()
+            if l_val > 0:
+                rot_mat = self._wigner(l_val, alpha, beta, gamma)
+                vals = x_rot[:, start:end].reshape(n, mul, 2 * l_val + 1)
+                rotated_vals = torch.einsum('nji,nmj->nmi', rot_mat, vals)
+                x_rot[:, start:end] = rotated_vals.reshape(n, -1)
 
-        for (mul, (l,p)), slice in zip(self.irreps_out, self.irreps_out.slices()):
-            if l > 0:
-                angle = xyz_to_angles(R[:,[1,2,0]]) # (tensor(N), tensor(N))
-                # The roataion matrix is SO3 rotation, therefore Irreps(l,1), is used here.
-                rot_mat_L = wigner_D(l, angle[0], angle[1], torch.zeros_like(angle[0]))
-                out[:, slice] = torch.einsum('nij,nmj->nmi', rot_mat_L, out[:, slice].reshape(n,mul,-1)).reshape(n,-1)
+        out = x.new_zeros(n, self.out_dim)
+
+        seg0_raw = x_rot[:, self.m_in_mask[0]]
+        seg0_for_fc0 = seg0_raw.clone()
+
+        current_col_in_seg0 = 0
+        for i_irrep in range(len(self.in_l)):
+            l_val_of_input_irrep = int(self.in_l[i_irrep].item())
+            mul_of_input_irrep = int(self.in_mul[i_irrep].item())
+
+            if l_val_of_input_irrep == 0:
+                seg0_for_fc0[:, current_col_in_seg0: current_col_in_seg0 + mul_of_input_irrep] = 0.0
+            current_col_in_seg0 += mul_of_input_irrep
+
+        if w is not None:
+            start_w = int(self.m_idx[0].item())
+            end_w = int(self.m_idx[1].item())
+            w_m0 = w[:, start_w:end_w]
+            if seg0_for_fc0.size(1) == w_m0.size(1):  # Ensure dimensions match for broadcasting/element-wise mul
+                seg0_for_fc0 = seg0_for_fc0 * w_m0
+            elif seg0_for_fc0.size(1) != 0 and w_m0.size(1) != 0:  # Both non-zero but mismatch
+                raise RuntimeError(
+                    f"Dimension mismatch for radial weights at m=0: seg0 has {seg0_for_fc0.size(1)}, w_m0 has {w_m0.size(1)}")
+            # If one is zero dim, multiplication might be okay or do nothing, depends on exact case.
+            # For safety, only multiply if dims match and are non-zero. If seg0 is empty, w_m0 should also be.
+
+        out[:, self.m_out_mask[0]] += self.fc0(seg0_for_fc0)
+
+        for idx, m_linear_layer in enumerate(self.m_linears):
+            m_val = idx + 1
+            if self.m_in_mask[m_val].any():
+                seg_m = x_rot[:, self.m_in_mask[m_val]].reshape(n, 2, -1)
+
+                if w is not None:
+                    start_w = int(self.m_idx[m_val].item())
+                    end_w = int(self.m_idx[m_val + 1].item())
+                    w_slice = w[:, start_w:end_w]
+                    if seg_m.size(2) == w_slice.size(1) and seg_m.size(2) > 0:
+                        seg_m = seg_m * w_slice.unsqueeze(1)
+                    elif seg_m.size(2) != 0 and w_slice.size(1) != 0:
+                        raise RuntimeError(
+                            f"Dimension mismatch for radial weights at m={m_val}: seg_m has {seg_m.size(2)}, w_slice has {w_slice.size(1)}")
+
+                processed_seg_m = m_linear_layer(seg_m).reshape(n, -1)
+                out[:, self.m_out_mask[m_val]] += processed_seg_m
+
+        for i in range(len(self.out_mul)):
+            start = int(self.out_offsets[i].item())
+            end = int(self.out_offsets[i + 1].item())
+            mul = int(self.out_mul[i].item())
+            l_val = int(self.out_l[i].item())
+
+            if l_val > 0:
+                rot_mat = self._wigner(l_val, alpha, beta, gamma)
+                vals = out[:, start:end].reshape(n, mul, 2 * l_val + 1)
+                out[:, start:end] = torch.einsum('nji,nmj->nmi', rot_mat, vals).reshape(n, -1)
 
         return out
 
-class SO2_m_Linear(torch.nn.Module):
-    """
-    SO(2) Conv: Perform an SO(2) convolution on features corresponding to +- m
 
-    Args:
-        m (int):                    Order of the spherical harmonic coefficients
-        sphere_channels (int):      Number of spherical channels
-        m_output_channels (int):    Number of output channels used during the SO(2) conv
-        lmax_list (list:int):       List of degrees (l) for each resolution
-        mmax_list (list:int):       List of orders (m) for each resolution
-    """
-    def __init__(
-        self,
-        m,
-        irreps_in,
-        irreps_out,
-    ):
-        super(SO2_m_Linear, self).__init__()
-        
-        self.m = m
-        self.irreps_in = irreps_in
-        self.irreps_out = irreps_out
-
-        assert self.irreps_in.lmax >= m
-        assert self.irreps_out.lmax >= m
-
-        self.num_in_channel = 0
-        for mul, (l, p) in self.irreps_in:
-            if l >= m:
-                self.num_in_channel += mul
-
-        self.num_out_channel = 0
-        for mul, (l, p) in self.irreps_out:
-            if l >= m:
-                self.num_out_channel += mul
-
-        self.fc = Linear(self.num_in_channel,
-            2 * self.num_out_channel,
-            bias=False)
-        self.fc.weight.data.mul_(1 / math.sqrt(2))
- 
-    def forward(self, x_m):
-        # x_m ~ [N, 2, n_irreps_m]
-        x_m = self.fc(x_m)
-        x_r = x_m.narrow(2, 0, self.fc.out_features // 2)
-        x_i = x_m.narrow(2, self.fc.out_features // 2, self.fc.out_features // 2)
-        x_m_r = x_r.narrow(1, 0, 1) - x_i.narrow(1, 1, 1) #x_r[:, 0] - x_i[:, 1]
-        x_m_i = x_r.narrow(1, 1, 1) + x_i.narrow(1, 0, 1) #x_r[:, 1] + x_i[:, 0]
-        x_out = torch.cat((x_m_r, x_m_i), dim=1)
-        
-        return x_out
-
-class RadialFunction(nn.Module):
-    '''
-        Contruct a radial function (linear layers + layer normalization + SiLU) given a list of channels
-    '''
-    def __init__(self, channels_list):
+@compile_mode("script")
+class SO2_m_Linear(nn.Module):
+    def __init__(self, m: int, irreps_in_s: Irreps, irreps_out_s: Irreps):
         super().__init__()
-        modules = []
-        input_channels = channels_list[0]
-        for i in range(len(channels_list)):
-            if i == 0:
-                continue
-            
-            modules.append(nn.Linear(input_channels, channels_list[i], bias=True))
-            input_channels = channels_list[i]
-            
-            if i == len(channels_list) - 1:
-                break
-            
-            modules.append(nn.LayerNorm(channels_list[i]))
-            modules.append(torch.nn.SiLU())
-        
-        self.net = nn.Sequential(*modules)
+        num_in = sum(mul for mul, (l, p_val) in irreps_in_s if l >= m)
+        num_out = sum(mul for mul, (l, p_val) in irreps_out_s if l >= m)
 
-        
-    def forward(self, inputs):
-        return self.net(inputs)
+        self.fc = Linear(num_in, 2 * num_out, bias=False)
+        if num_in > 0 and num_out > 0:
+            self.fc.weight.data.mul_(1.0 / math.sqrt(2.0))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if x.size(2) == 0:
+            if self.fc.out_features == 0:
+                return torch.empty((x.size(0), 2, 0), dtype=x.dtype, device=x.device)
+            # If num_in is 0, but num_out > 0, fc(x) will still produce output of shape [N, 2, 2*num_out]
+            # where the input to fc was effectively zeros.
+            # So, proceed with fc(x) even if x.size(2) == 0, as fc handles it.
+
+        y = self.fc(x)
+
+        num_out_channels = y.size(2) // 2
+        if num_out_channels == 0:
+            return torch.empty((x.size(0), 2, 0), dtype=x.dtype, device=x.device)
+
+        out_re = y[:, 0, :num_out_channels] - y[:, 1, num_out_channels:]
+        out_im = y[:, 0, num_out_channels:] + y[:, 1, :num_out_channels]
+
+        return torch.stack((out_re, out_im), dim=1)
+

--- a/dptb/nn/tensor_product.py
+++ b/dptb/nn/tensor_product.py
@@ -3,22 +3,18 @@ import math
 import torch
 import torch.nn as nn
 from torch.nn import Linear
-from typing import List, Optional, Tuple
+from typing import List, Optional
 from e3nn.o3 import xyz_to_angles, Irreps
 from e3nn.util.jit import compile_mode
-
 
 _Jd_file = os.path.join(os.path.dirname(__file__), "Jd.pt")
 if os.path.exists(_Jd_file):
     _Jd = torch.load(_Jd_file)
 else:
-    print(f"Warning: Jd.pt not found at {_Jd_file}. Wigner D functions will fail.")
-    _Jd = []
+    raise RuntimeError(f"Jd.pt not found at {_Jd_file}. Wigner D functions will fail.")
 
 
 def wigner_D(l: int, alpha: torch.Tensor, beta: torch.Tensor, gamma: torch.Tensor) -> torch.Tensor:
-    if not _Jd:
-        raise RuntimeError("Jd.pt was not loaded. Cannot compute Wigner D matrices.")
     if not l < len(_Jd):
         raise NotImplementedError(
             f"wigner D maximum l implemented is {len(_Jd) - 1}, send us an email to ask for more"
@@ -59,111 +55,97 @@ class SO2_Linear(nn.Module):
             extra_m0_outsize: int = 0,
     ):
         super().__init__()
-        if not _Jd:
-            raise RuntimeError("Jd.pt was not loaded. SO2_Linear cannot be initialized.")
         self.Jd: List[torch.Tensor] = _Jd
 
         irreps_in_s = irreps_in.simplify()
         irreps_out_s = (Irreps(f"{extra_m0_outsize}x0e") + irreps_out).simplify()
 
-        self.irreps_out: Irreps = irreps_out_s
+        self.irreps_out = irreps_out_s
         self.in_dim = irreps_in_s.dim
         self.out_dim = irreps_out_s.dim
         self.in_num_irreps = irreps_in_s.num_irreps
         self.out_num_irreps = irreps_out_s.num_irreps
         self.has_radial = radial_emb
 
-        if radial_channels is None:
-            radial_channels = []
+        # Buffers for irreps layout
+        in_offsets, in_mul, in_l = [], [], []
+        offset = 0
+        for mul, (l, _) in irreps_in_s:
+            in_offsets.append(offset)
+            in_mul.append(mul)
+            in_l.append(l)
+            offset += mul * (2 * l + 1)
+        in_offsets.append(offset)
+        self.register_buffer('in_offsets', torch.tensor(in_offsets, dtype=torch.long))
+        self.register_buffer('in_mul', torch.tensor(in_mul, dtype=torch.long))
+        self.register_buffer('in_l', torch.tensor(in_l, dtype=torch.long))
 
-        in_offsets_list: List[int] = []
-        in_mul_list: List[int] = []
-        in_l_list: List[int] = []
-        current_offset = 0
-        for mul, (l, p_val) in irreps_in_s:
-            in_offsets_list.append(current_offset)
-            in_mul_list.append(mul)
-            in_l_list.append(l)
-            current_offset += mul * (2 * l + 1)
-        in_offsets_list.append(current_offset)
-        self.register_buffer('in_offsets', torch.tensor(in_offsets_list, dtype=torch.long))
-        self.register_buffer('in_mul', torch.tensor(in_mul_list, dtype=torch.long))
-        self.register_buffer('in_l', torch.tensor(in_l_list, dtype=torch.long))
+        out_offsets, out_mul, out_l = [], [], []
+        offset = 0
+        for mul, (l, _) in irreps_out_s:
+            out_offsets.append(offset)
+            out_mul.append(mul)
+            out_l.append(l)
+            offset += mul * (2 * l + 1)
+        out_offsets.append(offset)
+        self.register_buffer('out_offsets', torch.tensor(out_offsets, dtype=torch.long))
+        self.register_buffer('out_mul', torch.tensor(out_mul, dtype=torch.long))
+        self.register_buffer('out_l', torch.tensor(out_l, dtype=torch.long))
 
-        out_offsets_list: List[int] = []
-        out_mul_list: List[int] = []
-        out_l_list: List[int] = []
-        current_offset = 0
-        for mul, (l, p_val) in irreps_out_s:
-            out_offsets_list.append(current_offset)
-            out_mul_list.append(mul)
-            out_l_list.append(l)
-            current_offset += mul * (2 * l + 1)
-        out_offsets_list.append(current_offset)
-        self.register_buffer('out_offsets', torch.tensor(out_offsets_list, dtype=torch.long))
-        self.register_buffer('out_mul', torch.tensor(out_mul_list, dtype=torch.long))
-        self.register_buffer('out_l', torch.tensor(out_l_list, dtype=torch.long))
-
+        # m-in mask and count
         m_in_mask = torch.zeros(irreps_in_s.lmax + 1, self.in_dim, dtype=torch.bool)
         cnt_list = [0] * (irreps_in_s.lmax + 1)
-
-        current_offset_for_mask = 0
-        for i in range(len(irreps_in_s)):
-            mul, (l, p_val) = irreps_in_s[i]
-            for k_mul in range(mul):
-                base_idx = current_offset_for_mask + k_mul * (2 * l + 1)
+        cur = 0
+        for mul, (l, _) in irreps_in_s:
+            for k in range(mul):
+                base = cur + k * (2 * l + 1)
                 for m_val in range(l + 1):
                     if m_val == 0:
-                        m_in_mask[m_val, base_idx + l] = True
+                        m_in_mask[m_val, base + l] = True
                         cnt_list[m_val] += 1
                     else:
-                        m_in_mask[m_val, base_idx + l + m_val] = True
-                        m_in_mask[m_val, base_idx + l - m_val] = True
+                        m_in_mask[m_val, base + l + m_val] = True
+                        m_in_mask[m_val, base + l - m_val] = True
                         cnt_list[m_val] += 1
-            current_offset_for_mask += mul * (2 * l + 1)
+            cur += mul * (2 * l + 1)
         self.register_buffer('m_in_mask', m_in_mask)
         self.register_buffer('cnt', torch.tensor(cnt_list, dtype=torch.long))
+        self.register_buffer('m_idx', torch.cat([torch.tensor([0], dtype=torch.long), torch.cumsum(torch.tensor(cnt_list, dtype=torch.long), dim=0)]))
 
-        m_idx = torch.cat([torch.tensor([0], dtype=torch.long), torch.cumsum(self.cnt, dim=0)])
-        self.register_buffer('m_idx', m_idx)
-
+        # m-out mask
         m_out_mask = torch.zeros(irreps_out_s.lmax + 1, self.out_dim, dtype=torch.bool)
-        current_offset_for_mask = 0
-        for i in range(len(irreps_out_s)):
-            mul, (l, p_val) = irreps_out_s[i]
-            for k_mul in range(mul):
-                base_idx = current_offset_for_mask + k_mul * (2 * l + 1)
+        cur = 0
+        for mul, (l, _) in irreps_out_s:
+            for k in range(mul):
+                base = cur + k * (2 * l + 1)
                 for m_val in range(l + 1):
                     if m_val <= irreps_in_s.lmax:
                         if m_val == 0:
-                            m_out_mask[m_val, base_idx + l] = True
+                            m_out_mask[m_val, base + l] = True
                         else:
-                            m_out_mask[m_val, base_idx + l + m_val] = True
-                            m_out_mask[m_val, base_idx + l - m_val] = True
-            current_offset_for_mask += mul * (2 * l + 1)
+                            m_out_mask[m_val, base + l + m_val] = True
+                            m_out_mask[m_val, base + l - m_val] = True
+            cur += mul * (2 * l + 1)
         self.register_buffer('m_out_mask', m_out_mask)
 
+        # fc0 and m_linears
         self.fc0 = Linear(self.in_num_irreps, self.out_num_irreps, bias=True)
+        self.m_linears = nn.ModuleList([SO2_m_Linear(mv, irreps_in_s, irreps_out_s) for mv in range(1, irreps_out_s.lmax + 1)])
 
-        self.m_linears = nn.ModuleList([
-            SO2_m_Linear(m, irreps_in_s, irreps_out_s) for m in range(1, irreps_out_s.lmax + 1)
-        ])
-
+        # radial embedding
         if self.has_radial:
-            if latent_dim <= 0:
-                raise ValueError("latent_dim must be > 0 if radial_emb is True")
             layers_list: List[nn.Module] = []
-            current_ch_radial = latent_dim
-            all_radial_net_channels = radial_channels + [int(m_idx[-1].item())]
-            for i, next_ch_radial in enumerate(all_radial_net_channels):
-                layers_list.append(Linear(current_ch_radial, next_ch_radial, bias=True))
-                current_ch_radial = next_ch_radial
-                if i < len(all_radial_net_channels) - 1:
-                    layers_list.append(nn.LayerNorm(next_ch_radial))
+            current_dim = latent_dim
+            all_radial_layer_dims = (radial_channels if radial_channels is not None else []) + [int(self.m_idx[-1].item())]
+            for i, out_ch in enumerate(all_radial_layer_dims):
+                layers_list.append(Linear(current_dim, out_ch, bias=True))
+                current_dim = out_ch
+                if i < len(all_radial_layer_dims) - 1:  # Not the last layer
+                    layers_list.append(nn.LayerNorm(out_ch))
                     layers_list.append(nn.SiLU())
-            self.radial: nn.Module = nn.Sequential(*layers_list)
+            self.radial = nn.Sequential(*layers_list)
         else:
-            self.radial: nn.Module = nn.Identity()  # Explicitly type self.radial here for clarity
+            self.radial = nn.Identity()
 
     def _wigner(self, l: int, alpha: torch.Tensor, beta: torch.Tensor, gamma: torch.Tensor) -> torch.Tensor:
         J = self.Jd[l].to(dtype=alpha.dtype, device=alpha.device)
@@ -179,114 +161,67 @@ class SO2_Linear(nn.Module):
         alpha, beta = xyz_to_angles(R[:, [1, 2, 0]])
         gamma = torch.zeros_like(alpha)
 
-        # MODIFIED PART FOR w CALCULATION
-        w: Optional[torch.Tensor] = None
+        # initialize radial weights tensor to empty or computed
+        w = torch.ones(n, int(self.m_idx[-1].item()), dtype=x.dtype, device=x.device)
         if self.has_radial:
             if latents is None:
-                raise RuntimeError("`latents` must be provided and be a Tensor when `radial_emb=True`")
+                raise RuntimeError("`latents` must be provided when `radial_emb=True`")
             w = self.radial(latents)
-            # END OF MODIFIED PART
 
-        x_rot = x.clone()
+        # initialize x_rot to zero
+        x_rot = torch.zeros_like(x)
         for i in range(len(self.in_mul)):
             start = int(self.in_offsets[i].item())
             end = int(self.in_offsets[i + 1].item())
             mul = int(self.in_mul[i].item())
             l_val = int(self.in_l[i].item())
-
             if l_val > 0:
-                rot_mat = self._wigner(l_val, alpha, beta, gamma)
-                vals = x_rot[:, start:end].reshape(n, mul, 2 * l_val + 1)
-                rotated_vals = torch.einsum('nji,nmj->nmi', rot_mat, vals)
-                x_rot[:, start:end] = rotated_vals.reshape(n, -1)
+                rot = self._wigner(l_val, alpha, beta, gamma)
+                vals = x[:, start:end].reshape(n, mul, 2 * l_val + 1)
+                x_rot[:, start:end] = torch.einsum('nji,nmj->nmi', rot, vals).reshape(n, -1)
 
         out = x.new_zeros(n, self.out_dim)
-
-        seg0_raw = x_rot[:, self.m_in_mask[0]]
-        seg0_for_fc0 = seg0_raw.clone()
-
-        current_col_in_seg0 = 0
-        for i_irrep in range(len(self.in_l)):
-            l_val_of_input_irrep = int(self.in_l[i_irrep].item())
-            mul_of_input_irrep = int(self.in_mul[i_irrep].item())
-
-            if l_val_of_input_irrep == 0:
-                seg0_for_fc0[:, current_col_in_seg0: current_col_in_seg0 + mul_of_input_irrep] = 0.0
-            current_col_in_seg0 += mul_of_input_irrep
-
-        if w is not None:
-            start_w = int(self.m_idx[0].item())
-            end_w = int(self.m_idx[1].item())
-            w_m0 = w[:, start_w:end_w]
-            if seg0_for_fc0.size(1) == w_m0.size(1):  # Ensure dimensions match for broadcasting/element-wise mul
-                seg0_for_fc0 = seg0_for_fc0 * w_m0
-            elif seg0_for_fc0.size(1) != 0 and w_m0.size(1) != 0:  # Both non-zero but mismatch
-                raise RuntimeError(
-                    f"Dimension mismatch for radial weights at m=0: seg0 has {seg0_for_fc0.size(1)}, w_m0 has {w_m0.size(1)}")
-            # If one is zero dim, multiplication might be okay or do nothing, depends on exact case.
-            # For safety, only multiply if dims match and are non-zero. If seg0 is empty, w_m0 should also be.
-
-        out[:, self.m_out_mask[0]] += self.fc0(seg0_for_fc0)
-
-        for idx, m_linear_layer in enumerate(self.m_linears):
+        # m=0
+        seg0 = x_rot[:, self.m_in_mask[0]]
+        if w is not None and seg0.numel() > 0:
+            seg0 = seg0 * w[:, self.m_idx[0]:self.m_idx[1]]
+        out[:, self.m_out_mask[0]] += self.fc0(seg0)
+        # m>0
+        for idx, layer in enumerate(self.m_linears):
             m_val = idx + 1
-            if self.m_in_mask[m_val].any():
-                seg_m = x_rot[:, self.m_in_mask[m_val]].reshape(n, 2, -1)
-
-                if w is not None:
-                    start_w = int(self.m_idx[m_val].item())
-                    end_w = int(self.m_idx[m_val + 1].item())
-                    w_slice = w[:, start_w:end_w]
-                    if seg_m.size(2) == w_slice.size(1) and seg_m.size(2) > 0:
-                        seg_m = seg_m * w_slice.unsqueeze(1)
-                    elif seg_m.size(2) != 0 and w_slice.size(1) != 0:
-                        raise RuntimeError(
-                            f"Dimension mismatch for radial weights at m={m_val}: seg_m has {seg_m.size(2)}, w_slice has {w_slice.size(1)}")
-
-                processed_seg_m = m_linear_layer(seg_m).reshape(n, -1)
-                out[:, self.m_out_mask[m_val]] += processed_seg_m
-
+            mask = self.m_in_mask[m_val]
+            if mask.any():
+                seg = x_rot[:, mask].reshape(n, 2, -1)
+                if w is not None and seg.numel() > 0:
+                    seg = seg * w[:, self.m_idx[m_val]:self.m_idx[m_val+1]].unsqueeze(1)
+                out[:, self.m_out_mask[m_val]] += layer(seg).reshape(n, -1)
+        # final rotation
         for i in range(len(self.out_mul)):
             start = int(self.out_offsets[i].item())
             end = int(self.out_offsets[i + 1].item())
-            mul = int(self.out_mul[i].item())
             l_val = int(self.out_l[i].item())
-
+            mul = int(self.out_mul[i].item())
             if l_val > 0:
-                rot_mat = self._wigner(l_val, alpha, beta, gamma)
+                rot = self._wigner(l_val, alpha, beta, gamma)
                 vals = out[:, start:end].reshape(n, mul, 2 * l_val + 1)
-                out[:, start:end] = torch.einsum('nji,nmj->nmi', rot_mat, vals).reshape(n, -1)
-
+                out[:, start:end] = torch.einsum('nji,nmj->nmi', rot, vals).reshape(n, -1)
         return out
 
 
 @compile_mode("script")
 class SO2_m_Linear(nn.Module):
-    def __init__(self, m: int, irreps_in_s: Irreps, irreps_out_s: Irreps):
+    def __init__(self, m_val: int, irreps_in_s: Irreps, irreps_out_s: Irreps):
         super().__init__()
-        num_in = sum(mul for mul, (l, p_val) in irreps_in_s if l >= m)
-        num_out = sum(mul for mul, (l, p_val) in irreps_out_s if l >= m)
-
+        # count input/output channels for order m_val
+        num_in = sum(mul for mul, (l, _) in irreps_in_s if l >= m_val)
+        num_out = sum(mul for mul, (l, _) in irreps_out_s if l >= m_val)
         self.fc = Linear(num_in, 2 * num_out, bias=False)
         if num_in > 0 and num_out > 0:
             self.fc.weight.data.mul_(1.0 / math.sqrt(2.0))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        if x.size(2) == 0:
-            if self.fc.out_features == 0:
-                return torch.empty((x.size(0), 2, 0), dtype=x.dtype, device=x.device)
-            # If num_in is 0, but num_out > 0, fc(x) will still produce output of shape [N, 2, 2*num_out]
-            # where the input to fc was effectively zeros.
-            # So, proceed with fc(x) even if x.size(2) == 0, as fc handles it.
-
         y = self.fc(x)
-
-        num_out_channels = y.size(2) // 2
-        if num_out_channels == 0:
-            return torch.empty((x.size(0), 2, 0), dtype=x.dtype, device=x.device)
-
-        out_re = y[:, 0, :num_out_channels] - y[:, 1, num_out_channels:]
-        out_im = y[:, 0, num_out_channels:] + y[:, 1, :num_out_channels]
-
-        return torch.stack((out_re, out_im), dim=1)
-
+        num_out = y.size(2) // 2
+        re = y[:, 0, :num_out] - y[:, 1, num_out:]
+        im = y[:, 0, num_out:] + y[:, 1, :num_out]
+        return torch.stack((re, im), dim=1)


### PR DESCRIPTION
Refactored the SO2 module to make it jit-friendly.
Triger script in main embedding module like SLEM & LEM.
However, no significant speed-up is achieved.

![图片1](https://github.com/user-attachments/assets/4a302322-dae2-4a58-9c46-dcec7977907c)

The test case is:
```
{
    "common_options": {
        "basis": {
            "Ag": "6s3p3d2f",
            "Al": "3s3p2d",
            "As": "3s3p2d",
            "Au": "6s3p3d2f",
            "Ba": "6s3p3d2f",
            "Be": "6s2p",
            "Bi": "3s3p3d2f",
            "C": "3s3p2d",
            "Ca": "6s3p2d",
            "Cd": "6s3p3d2f",
            "Cl": "3s3p2d",
            "Co": "6s3p3d2f",
            "Cr": "6s3p3d2f",
            "Cs": "3s2p1d",
            "Cu": "6s3p3d2f",
            "F": "3s3p2d",
            "Fe": "6s3p3d2f",
            "Ga": "3s3p3d2f",
            "Ge": "3s3p3d2f",
            "H": "3s2p",
            "Hf": "6s3p3d2f",
            "Hg": "3s2p3d",
            "In": "3s3p3d2f",
            "Ir": "6s3p3d2f",
            "K": "3s2p1d",
            "La": "6s3p3d2f",
            "Li": "6s2p",
            "Mg": "3s2p1d",
            "Mn": "6s3p3d2f",
            "Mo": "6s3p3d2f",
            "N": "3s3p2d",
            "Na": "6s3p2d",
            "Nb": "6s3p3d2f",
            "Ni": "6s3p3d2f",
            "O": "3s3p2d",
            "Os": "6s3p3d2f",
            "Pb": "3s3p3d2f",
            "Pd": "6s3p3d2f",
            "Pt": "6s3p3d2f",
            "Rb": "3s2p1d",
            "Re": "6s3p3d2f",
            "Rh": "6s3p3d2f",
            "Ru": "6s3p3d2f",
            "Sc": "6s3p3d2f",
            "Si": "3s3p2d",
            "Sn": "3s3p3d2f",
            "Sr": "6s3p2d",
            "Ta": "6s3p3d2f",
            "Tc": "6s3p3d2f",
            "Ti": "6s3p3d2f",
            "Tl": "3s3p3d2f",
            "V": "6s3p3d2f",
            "W": "6s3p3d3f",
            "Y": "6s3p3d2f",
            "Zn": "6s3p3d2f",
            "Zr": "6s3p3d2f"
        },
        "device": "cuda",
        "overlap": true
    },
    "model_options": {
        "embedding": {
            "method": "lem",
            "n_layers": 5,
            "avg_num_neighbors": 80,
            "irreps_hidden": "512x0e+256x1o+128x2e+64x3o+64x4e+32x5o+32x6e",
            "r_max": {
                "Ag": 7.408480947893776,
                "Al": 7.408480947893776,
                "As": 7.408480947893776,
                "Au": 7.408480947893776,
                "Ba": 8.466835369021458,
                "Be": 7.408480947893776,
                "Bi": 9.52518979014914,
                "C": 7.408480947893776,
                "Ca": 9.52518979014914,
                "Cd": 7.408480947893776,
                "Cl": 7.408480947893776,
                "Co": 7.408480947893776,
                "Cr": 7.408480947893776,
                "Cs": 10.583544211276823,
                "Cu": 7.408480947893776,
                "F": 7.408480947893776,
                "Fe": 7.408480947893776,
                "Ga": 7.408480947893776,
                "Ge": 7.408480947893776,
                "H": 7.408480947893776,
                "Hf": 7.408480947893776,
                "Hg": 7.408480947893776,
                "In": 7.408480947893776,
                "Ir": 7.408480947893776,
                "K": 10.583544211276823,
                "La": 9.52518979014914,
                "Li": 9.52518979014914,
                "Mg": 10.583544211276823,
                "Mn": 7.408480947893776,
                "Mo": 7.408480947893776,
                "N": 7.408480947893776,
                "Na": 10.583544211276823,
                "Nb": 7.408480947893776,
                "Ni": 7.408480947893776,
                "O": 7.408480947893776,
                "Os": 7.408480947893776,
                "Pb": 8.466835369021458,
                "Pd": 7.408480947893776,
                "Pt": 7.408480947893776,
                "Rb": 10.583544211276823,
                "Re": 7.408480947893776,
                "Rh": 7.408480947893776,
                "Ru": 7.408480947893776,
                "Sc": 7.408480947893776,
                "Si": 7.408480947893776,
                "Sn": 8.466835369021458,
                "Sr": 8.466835369021458,
                "Ta": 7.408480947893776,
                "Tc": 7.408480947893776,
                "Ti": 7.408480947893776,
                "Tl": 8.466835369021458,
                "V": 7.408480947893776,
                "W": 7.408480947893776,
                "Y": 7.408480947893776,
                "Zn": 7.408480947893776,
                "Zr": 7.408480947893776
            },
            "universal": true,
            "tp_radial_emb": true
        },
        "prediction": {
            "method": "e3tb",
            "neurons": [
                64,
                64
            ]
        }
    },
    "train_options": {
        "batch_size": 5,
        "num_epoch": 1000,
        "optimizer": {
            "lr": 0.005,
            "type": "Adam"
        },
        "lr_scheduler": {
            "type": "rop",
            "factor": 0.9,
            "patience": 1000,
            "min_lr": 1e-07
        },
        "loss_options": {
            "train": {
                "method": "hamil_abs",
                "onsite_shift": true
            },
            "validation": {
                "method": "hamil_abs",
                "onsite_shift": true
            }
        },
        "save_freq": 1000,
        "validation_freq": 1000,
        "display_freq": 100,
        "sliding_win_size": 1000,
        "update_lr_per_iter": true,
        "use_tensorboard": true
    },
    "data_options": {
        "train": {
            "root": "/bohr/mp20-0422-m344/v1/splited_lmdb_data/train",
            "prefix": "data",
            "type": "LMDBDataset",
            "get_Hamiltonian": true,
            "get_overlap": true
        },
        "validation": {
            "root": "/bohr/mp20-0422-m344/v1/splited_lmdb_data/valid",
            "prefix": "data",
            "type": "LMDBDataset",
            "get_Hamiltonian": true,
            "get_overlap": true
        }
    }
}
```
For the SLEM model, the batch size =5 is terminated for over-comsuming memory. Batch size=3 is okay.
The comparision above is LEM with jit and no jit.