### PR TITLE
fix: add checks for basis existence in NNSK methods to prevent key err

### DIFF
--- a/dptb/nn/nnsk.py
+++ b/dptb/nn/nnsk.py
@@ -1021,6 +1021,8 @@ class NNSK(torch.nn.Module):
             rev_line = self.idp_sk.transform_bond(jan, ian)
             for orbpair, slices in self.idp_sk.orbpair_maps.items():
                 fiorb, fjorb = orbpair.split("-")
+                if fiorb not in self.idp_sk.full_basis_to_basis[iasym] or fjorb not in self.idp_sk.full_basis_to_basis[jasym]:
+                    continue
                 iorb = self.idp_sk.full_basis_to_basis[iasym].get(fiorb)
                 jorb = self.idp_sk.full_basis_to_basis[jasym].get(fjorb)
                 if to_uniform:
@@ -1060,6 +1062,8 @@ class NNSK(torch.nn.Module):
                 rev_line = self.idp_sk.transform_bond(jan, ian)
                 for orbpair, slices in self.idp_sk.orbpair_maps.items():
                     fiorb, fjorb = orbpair.split("-")
+                    if fiorb not in self.idp_sk.full_basis_to_basis[iasym] or fjorb not in self.idp_sk.full_basis_to_basis[jasym]:
+                        continue
                     iorb = self.idp_sk.full_basis_to_basis[iasym].get(fiorb)
                     jorb = self.idp_sk.full_basis_to_basis[jasym].get(fjorb)
                     if to_uniform:
@@ -1093,6 +1097,8 @@ class NNSK(torch.nn.Module):
                 for asym in self.idp_sk.type_names:
                     for orbpair, slices in self.idp_sk.skonsite_maps.items():
                         fiorb, fjorb = orbpair.split("-")
+                        if fiorb not in self.idp_sk.full_basis_to_basis[asym] or fjorb not in self.idp_sk.full_basis_to_basis[asym]:
+                            continue
                         if fiorb != fjorb:
                             iorb = self.idp_sk.full_basis_to_basis[asym][fiorb]
                             jorb = self.idp_sk.full_basis_to_basis[asym][fjorb]
@@ -1112,6 +1118,8 @@ class NNSK(torch.nn.Module):
                 ian, jan = torch.tensor(atomic_num_dict[iasym]), torch.tensor(atomic_num_dict[jasym])
                 for orbpair, slices in self.idp_sk.orbpair_maps.items():
                     fiorb, fjorb = orbpair.split("-")
+                    if fiorb not in self.idp_sk.full_basis_to_basis[iasym] or fjorb not in self.idp_sk.full_basis_to_basis[jasym]:
+                        continue
                     iorb = self.idp_sk.full_basis_to_basis[iasym].get(fiorb)
                     jorb = self.idp_sk.full_basis_to_basis[jasym].get(fjorb)
                     if to_uniform:
@@ -1128,6 +1136,8 @@ class NNSK(torch.nn.Module):
             for asym in self.idp_sk.type_names:
                 for orbpair, slices in self.idp_sk.skonsite_maps.items():
                     fiorb, fjorb = orbpair.split("-")
+                    if fiorb not in self.idp_sk.full_basis_to_basis[asym] or fjorb not in self.idp_sk.full_basis_to_basis[asym]:
+                        continue
                     iorb = self.idp_sk.full_basis_to_basis[asym][fiorb]
                     jorb = self.idp_sk.full_basis_to_basis[asym][fjorb]
                     if to_uniform:
@@ -1153,6 +1163,8 @@ class NNSK(torch.nn.Module):
             soc_param = {}
             for asym in self.idp_sk.type_names:
                 for fiorb, slices in self.idp_sk.sksoc_maps.items():
+                    if fiorb not in self.idp_sk.full_basis_to_basis[asym]:
+                        continue
                     iorb = self.idp_sk.full_basis_to_basis[asym][fiorb]
                     if to_uniform:
                         iorb = basisref[asym][iorb]


### PR DESCRIPTION
This pull request improves the robustness of the `to_json` method in `dptb/nn/nnsk.py` by adding checks to ensure that orbital pairs and orbitals exist in the `full_basis_to_basis` mapping before attempting to access or process them. These changes prevent potential `KeyError` exceptions and improve the method's reliability.

### Enhancements to error handling in `to_json`:

* **Orbital pair validation in `orbpair_maps` loops**: Added checks to ensure both orbitals in a pair exist in the `full_basis_to_basis` mapping for the given asymmetry types (`iasym` and `jasym`) before proceeding with further processing. This change was applied in multiple loops. [[1]](diffhunk://#diff-2f8dcf5c846087e4da5e05510eab7bfa713f06b77d1bf2959fd8c2b9ba37f173R1024-R1025) [[2]](diffhunk://#diff-2f8dcf5c846087e4da5e05510eab7bfa713f06b77d1bf2959fd8c2b9ba37f173R1065-R1066) [[3]](diffhunk://#diff-2f8dcf5c846087e4da5e05510eab7bfa713f06b77d1bf2959fd8c2b9ba37f173R1121-R1122)

* **Orbital pair validation in `skonsite_maps` loops**: Added similar checks for orbital pairs in the `skonsite_maps` loops to ensure both orbitals exist in the `full_basis_to_basis` mapping for a given asymmetry type (`asym`). [[1]](diffhunk://#diff-2f8dcf5c846087e4da5e05510eab7bfa713f06b77d1bf2959fd8c2b9ba37f173R1100-R1101) [[2]](diffhunk://#diff-2f8dcf5c846087e4da5e05510eab7bfa713f06b77d1bf2959fd8c2b9ba37f173R1139-R1140)

* **Single orbital validation in `sksoc_maps` loop**: Added a check to ensure that a single orbital exists in the `full_basis_to_basis` mapping for a given asymmetry type (`asym`) before processing.…rors