### PR TITLE
hot fix: average loss for non-fast validation only

### DIFF
--- a/dptb/nnops/trainer.py
+++ b/dptb/nnops/trainer.py
@@ -232,5 +232,6 @@ class Trainer(BaseTrainer):
 
                 if fast:
                     break
-        loss = loss / len(self.validation_loader)
+        if not fast:
+            loss = loss / len(self.validation_loader)
         return loss


### PR DESCRIPTION
The old way will average loss for fast validation, which is not intended. Sorry