### PR TITLE
feat: Add support for eigenvalue solvers 'torch' and 'numpy'

### DIFF
--- a/dptb/nn/dftb2nnsk.py
+++ b/dptb/nn/dftb2nnsk.py
@@ -10,6 +10,7 @@ from dptb.utils.constants import atomic_num_dict
 import matplotlib.pyplot as plt
 from torch.optim import Adam, LBFGS, RMSprop, SGD
 from torch.optim.lr_scheduler import ExponentialLR, CosineAnnealingLR
+from functorch import vmap
 from dptb.nn.nnsk import NNSK
 from dptb.nn.sktb.onsite import onsite_energy_database
 from dptb.data.AtomicData import get_r_map, get_r_map_bondwise

--- a/dptb/nn/energy.py
+++ b/dptb/nn/energy.py
@@ -10,6 +10,8 @@ from dptb.nn.hr2hk import HR2HK
 from typing import Union, Optional, Dict, List
 from dptb.data.transforms import OrbitalMapper
 from dptb.data import AtomicDataDict
+import logging
+log = logging.getLogger(__name__)
 
 class Eigenvalues(nn.Module):
     def __init__(
@@ -55,7 +57,18 @@ class Eigenvalues(nn.Module):
         self.s_out_field = s_out_field
 
 
-    def forward(self, data: AtomicDataDict.Type, nk: Optional[int]=None) -> AtomicDataDict.Type:
+    def forward(self, 
+                data: AtomicDataDict.Type, 
+                nk: Optional[int]=None,
+                eig_solver: str='torch') -> AtomicDataDict.Type:
+
+        if eig_solver is None:
+            eig_solver = 'torch'
+            log.warning("eig_solver is not set, using default 'torch'.")
+        if eig_solver not in ['torch', 'numpy']:
+            log.error(f"eig_solver should be 'torch' or 'numpy', but got {eig_solver}.")
+            raise ValueError        
+
         kpoints = data[AtomicDataDict.KPOINT_KEY]
         if kpoints.is_nested:
             nested = True
@@ -72,13 +85,22 @@ class Eigenvalues(nn.Module):
             data = self.h2k(data)
             if self.overlap:
                 data = self.s2k(data)
-                chklowt = torch.linalg.cholesky(data[self.s_out_field])
-                chklowtinv = torch.linalg.inv(chklowt)
-                data[self.h_out_field] = (chklowtinv @ data[self.h_out_field] @ torch.transpose(chklowtinv,dim0=1,dim1=2).conj())
+                if eig_solver == 'torch':
+                    chklowt = torch.linalg.cholesky(data[self.s_out_field])
+                    chklowtinv = torch.linalg.inv(chklowt)
+                    data[self.h_out_field] = (chklowtinv @ data[self.h_out_field] @ torch.transpose(chklowtinv,dim0=1,dim1=2).conj())
+                elif eig_solver == 'numpy':
+                    chklowt = np.linalg.cholesky(data[self.s_out_field].detach().numpy())
+                    chklowtinv = np.linalg.inv(chklowt)
+                    data[self.h_out_field] = (chklowtinv @ data[self.h_out_field].detach().numpy() @ np.transpose(chklowtinv,(0,2,1)).conj())
             else:
                 data[self.h_out_field] = data[self.h_out_field]
             
-            eigvals.append(torch.linalg.eigvalsh(data[self.h_out_field]))
+            if eig_solver == 'torch':
+                eigvals.append(torch.linalg.eigvalsh(data[self.h_out_field]))
+            elif eig_solver == 'numpy':
+                eigvals.append(torch.from_numpy(np.linalg.eigvalsh(a=data[self.h_out_field])))
+
         data[self.out_field] = torch.nested.as_nested_tensor([torch.cat(eigvals, dim=0)])
         if nested:
             data[AtomicDataDict.KPOINT_KEY] = torch.nested.as_nested_tensor([kpoints])

--- a/dptb/postprocess/bandstructure/band.py
+++ b/dptb/postprocess/bandstructure/band.py
@@ -212,7 +212,13 @@ class Band(ElecStruCal):
         if kpath_kwargs.get("override_overlap", None):
             override_overlap = kpath_kwargs["override_overlap"]
         
-        data, eigenvalues = self.get_eigs(data=data, klist=klist, pbc=pbc, AtomicData_options=AtomicData_options, override_overlap=override_overlap)
+        eig_solver = None
+        if kpath_kwargs.get("eig_solver", None):
+            eig_solver = kpath_kwargs["eig_solver"]
+        
+        data, eigenvalues = self.get_eigs(data=data, klist=klist, pbc=pbc, 
+                                          AtomicData_options=AtomicData_options, 
+                                          override_overlap=override_overlap, eig_solver=eig_solver)
         
 
         # get the E_fermi from data
@@ -232,8 +238,9 @@ class Band(ElecStruCal):
         # else:
         #     estimated_E_fermi = None
         if nel_atom is not None:
-            data,estimated_E_fermi = self.get_fermi_level(data=data, nel_atom=nel_atom, \
-                        klist = klist, pbc=pbc, AtomicData_options=AtomicData_options)
+            data,estimated_E_fermi = self.get_fermi_level(  data=data, nel_atom=nel_atom,
+                                                            klist = klist, pbc=pbc, 
+                                                            AtomicData_options=AtomicData_options)
         else:
             estimated_E_fermi = None
 

--- a/dptb/postprocess/elec_struc_cal.py
+++ b/dptb/postprocess/elec_struc_cal.py
@@ -175,7 +175,8 @@ class ElecStruCal(object):
                  klist: np.ndarray,
                  pbc:Union[bool,list]=None,
                  AtomicData_options:dict=None,
-                 override_overlap:Optional[str]=None):
+                 override_overlap:Optional[str]=None,
+                 eig_solver:Optional[str]=None):
         '''This function calculates eigenvalues for Hk at specified k-points.
         
         Parameters
@@ -210,13 +211,14 @@ class ElecStruCal(object):
             data[AtomicDataDict.NODE_OVERLAP_KEY] = override_overlap_node
         if self.overlap or isinstance(override_overlap, str):
             assert data.get(AtomicDataDict.EDGE_OVERLAP_KEY) is not None
-        data = self.eigv(data)
+        data = self.eigv(data, eig_solver=eig_solver)
 
         return data, data[AtomicDataDict.ENERGY_EIGENVALUE_KEY][0].detach().cpu().numpy()
 
     def get_fermi_level(self, data: Union[AtomicData, ase.Atoms, str], nel_atom: dict, \
-                        meshgrid: list = None, klist: np.ndarray=None, pbc:Union[bool,list]=None,AtomicData_options:dict=None,
-                        q_tol:float=1e-10,smearing_method:str='FD',temp:float=300):
+                        meshgrid: list = None, klist: np.ndarray=None, pbc:Union[bool,list]=None,
+                        AtomicData_options:dict=None, q_tol:float=1e-10, smearing_method:str='FD', 
+                        temp:float=300,eig_solver:Optional[str]='torch'):
         '''This function calculates the Fermi level based on provided data with iteration method, electron counts per atom, and
         optional parameters like specific k-points and eigenvalues.
         
@@ -277,7 +279,9 @@ class ElecStruCal(object):
 
         # eigenvalues would be used if provided, otherwise the eigenvalues would be calculated from the model on the specified k-points
         if not AtomicDataDict.ENERGY_EIGENVALUE_KEY in data:
-            data, eigs = self.get_eigs(data=data, klist=klist, pbc=pbc, AtomicData_options=AtomicData_options) 
+            data, eigs = self.get_eigs(data=data, klist=klist, pbc=pbc, 
+                                       AtomicData_options=AtomicData_options,
+                                       eig_solver=eig_solver) 
             log.info('Getting eigenvalues from the model.')
         else:
             log.info('The eigenvalues are already in data. will use them.')

--- a/dptb/tests/test_band.py
+++ b/dptb/tests/test_band.py
@@ -46,6 +46,7 @@ def test_normal_band():
                 results_path="./",
                 device=model.device)
 
+    jdata["task_options"]["eig_solver"] = 'torch'
     eigenstatus = bcal.get_bands(data=dataset[0],
                                  kpath_kwargs=jdata["task_options"])
 
@@ -115,19 +116,28 @@ def test_normal_band():
         1.722770500183105469e+01, 1.725421524047851562e+01, 1.729618835449218750e+01, 1.736883163452148438e+01,
         1.810172653198242188e+01, 1.811395263671875000e+01, 1.814074897766113281e+01, 1.816400146484375000e+01],
         dtype=np.float32)
-
+    # torch diagnalization test
+    assert np.allclose(eigenstatus["eigenvalues"][0], expected_value_k1, atol=1e-4)
+    
+    
+    jdata["task_options"]["eig_solver"] = 'numpy'
+    eigenstatus = bcal.get_bands(data=dataset[0],
+                                 kpath_kwargs=jdata["task_options"])
+    # numpy diagnalization test
     assert np.allclose(eigenstatus["eigenvalues"][0], expected_value_k1, atol=1e-4)
 
-
 def test_band_false_overlap():
+
     jdata = normal_jdata
+
+    # torch diagnalization test
+    jdata["task_options"]["eig_solver"] = 'torch'
     jdata["task_options"]["override_overlap"] = f"{rootdir}/e3_band/false_overlaps.h5"
 
     bcal = Band(model=model,
                 use_gui=False,
                 results_path="./",
                 device=model.device)
-
     try:
         bcal.get_bands(data=dataset[0],
                        kpath_kwargs=jdata["task_options"])
@@ -136,8 +146,23 @@ def test_band_false_overlap():
     else:
         raise RuntimeError("false_overlap function normally.")
 
+    # numpy diagnalization test
+    jdata["task_options"]["eig_solver"] = 'numpy'
+    jdata["task_options"]["override_overlap"] = f"{rootdir}/e3_band/false_overlaps.h5"
+
+    try:
+        bcal.get_bands(data=dataset[0],
+                       kpath_kwargs=jdata["task_options"])
+    except np.linalg.LinAlgError as e:
+        pass
+    else:
+        raise RuntimeError("false_overlap function normally.")
+
+
+
 def test_band_override_overlap():
     jdata = normal_jdata
+    jdata["task_options"]["eig_solver"] = 'torch'
     jdata["task_options"]["override_overlap"] = f"{rootdir}/e3_band/data/Si64.0/overlaps.h5"
 
     bcal = Band(model=model,
@@ -216,3 +241,11 @@ def test_band_override_overlap():
         dtype=np.float32)
 
     assert np.allclose(eigenstatus["eigenvalues"][0], expected_value_k1, atol=1e-4)
+
+    jdata["task_options"]["eig_solver"] = 'numpy'
+    eigenstatus = bcal.get_bands(data=dataset[0],
+                                 kpath_kwargs=jdata["task_options"])
+    assert np.allclose(eigenstatus["eigenvalues"][0], expected_value_k1, atol=1e-4)
+
+
+

--- a/dptb/tests/test_get_fermi.py
+++ b/dptb/tests/test_get_fermi.py
@@ -18,10 +18,20 @@ def test_get_fermi():
     elec_cal = ElecStruCal(model=model,device='cpu')
     _, efermi =elec_cal.get_fermi_level(data=stru_data, 
                     nel_atom = nel_atom,smearing_method='FD',
-                meshgrid=[30,30,30])
+                    meshgrid=[30,30,30],eig_solver='torch')
     assert abs(efermi  + 3.2262574434280395) < 1e-3
 
     _, efermi =elec_cal.get_fermi_level(data=stru_data, 
                     nel_atom = nel_atom,smearing_method='Gaussian',
-                meshgrid=[30,30,30])
+                    meshgrid=[30,30,30],eig_solver='torch')
+    assert abs(efermi  + 3.2262574434280395) < 1e-3
+
+    _, efermi =elec_cal.get_fermi_level(data=stru_data, 
+                    nel_atom = nel_atom,smearing_method='FD',
+                    meshgrid=[30,30,30],eig_solver='numpy')
+    assert abs(efermi  + 3.2262574434280395) < 1e-3
+
+    _, efermi =elec_cal.get_fermi_level(data=stru_data, 
+                    nel_atom = nel_atom,smearing_method='Gaussian',
+                    meshgrid=[30,30,30],eig_solver='numpy')
     assert abs(efermi  + 3.2262574434280395) < 1e-3

--- a/dptb/utils/argcheck.py
+++ b/dptb/utils/argcheck.py
@@ -1251,6 +1251,7 @@ def band():
     doc_high_sym_kpoints = "the high symmetry kpoints dict, e.g. {'G':[0,0,0],'K':[0.5,0.5,0]}, only used for kline_type is vasp"
     doc_num_in_line = "the number of kpoints in each line path, only used for kline_type is vasp."
     doc_override_overlap = "overlap file path to be input to override overlap matrix."
+    doc_eig_solver = "the eigenvalue solver to be used."
     return [
         Argument("kline_type", str, optional=False, doc=doc_kline_type),
         Argument("kpath", [str,list], optional=False, doc=doc_kpath),
@@ -1263,7 +1264,8 @@ def band():
         Argument("nkpoints", int, optional=True, doc=doc_emax, default=0),
         Argument("ref_band", [str, None], optional=True, default=None, doc=doc_ref_band),
         Argument("nel_atom", [dict,None], optional=True, default=None, doc=doc_nel_atom),
-        Argument("override_overlap", [str, None], optional=True, default=None, doc=doc_override_overlap)
+        Argument("override_overlap", [str, None], optional=True, default=None, doc=doc_override_overlap),
+        Argument("eig_solver", [str, None], optional=True, default=None, doc=doc_eig_solver)
     ]
 
 


### PR DESCRIPTION
Introduce the ability to choose between 'torch' and 'numpy' for eigenvalue calculations, enhancing flexibility in solving eigenvalue problems for post-process of dptb. Update relevant functions and tests to accommodate this new feature.