### PR TITLE
feat: Add delete overlap option to pth2json and improve model saving …

### DIFF
--- a/dptb/entrypoints/main.py
+++ b/dptb/entrypoints/main.py
@@ -203,6 +203,12 @@ def main_parser() -> argparse.ArgumentParser:
         help="The pth ckpt to be transfered to json.",
     )
     parser_pth2json.add_argument(
+        "-dels", 
+        "--deleteoverlap",
+        help="Transfer to no overlap version.",
+        action="store_true"
+    )
+    parser_pth2json.add_argument(
         "-o",
         "--outdir",
         type=str,

--- a/dptb/entrypoints/pth2json.py
+++ b/dptb/entrypoints/pth2json.py
@@ -38,6 +38,24 @@ def pth2json(
 
     json_dict = nnsk.to_json()
 
+    if kwargs.get("deleteoverlap", False):
+        log.info("The deleteoverlap option is set. The model will be converted to orthogonal version.")
+        # convert the model to orthogonal version
+        log.info("Converting the model to orthogonal version.")
+        # remove the overlap key in the json_dict
+        if "overlap" in json_dict['model_params']:
+            del json_dict['model_params']["overlap"]
+        json_dict['common_options']['overlap'] = False
+
+        if json_dict['model_options']['nnsk'].get('freeze',False) == ['overlap']:
+            json_dict['model_options']['nnsk']['freeze'] = False
+        elif isinstance(json_dict['model_options']['nnsk'].get('freeze',False), list):
+            json_dict['model_options']['nnsk']['freeze'] = [x for x in json_dict['model_options']['nnsk']['freeze'] if x != 'overlap']
+        
+        # turn off the push option in the ckpt json
+        if isinstance(json_dict['model_options']['nnsk'].get('push',False), dict):
+            json_dict['model_options']['nnsk']['push'] = False
+
     # dump the json file
     json_file = Path(outdir) / "ckpt.json"
     with open(json_file, "w") as f:

--- a/dptb/plugins/saver.py
+++ b/dptb/plugins/saver.py
@@ -66,11 +66,6 @@ class Saver(Plugin):
         if len(self.latest_quene) > max_ckpt:
             delete_name = self.latest_quene.pop(0)
             delete_path = os.path.join(self.checkpoint_path, delete_name+".pth")
-            os.remove(delete_path)
-
-        if len(self.latest_quene) > max_ckpt:
-            delete_name = self.latest_quene.pop(0)
-            delete_path = os.path.join(self.checkpoint_path, delete_name+".pth")
             try:        
                 os.remove(delete_path)
             except:

--- a/dptb/utils/argcheck.py
+++ b/dptb/utils/argcheck.py
@@ -1679,7 +1679,10 @@ def collect_cutoffs(jdata):
     r_max, er_max, oer_max = get_cutoffs_from_model_options(model_options)
 
     if model_options.get("nnsk", None) is not None:
-        if model_options["nnsk"]["push"]:
+        if model_options["nnsk"]["push"] and \
+            abs(model_options["nnsk"]["push"]['rs_thr']) + \
+            abs(model_options["nnsk"]["push"]['rc_thr']) + \
+            abs(model_options["nnsk"]["push"]['w_thr']) > 1e-8:
             assert jdata.get("data_options",None) is not None, "data_options should be provided in jdata for nnsk push"
             assert jdata['data_options'].get("r_max") is not None, "r_max should be provided in data_options for nnsk push"
             log.info('YOU ARE USING NNSK PUSH MODEL, r_max will be used from data_options. Be careful! check the value in data options and model options. r_max or rs/rc !')


### PR DESCRIPTION
This pull request introduces a new option to convert models to a "no overlap" (orthogonal) version during checkpoint conversion, and includes several improvements and bug fixes related to model configuration and checkpoint handling. The most important changes are grouped below.

### New feature: No-overlap model conversion

* Added a `--deleteoverlap` flag to the `pth2json` CLI command in `main.py`, enabling users to convert models to a version without the "overlap" parameter.
* Implemented logic in `pth2json.py` to remove the "overlap" key from the model parameters, update related options, and ensure orthogonal conversion when the flag is set.

### Model configuration bug fixes

* Improved handling of the `push` option in `argcheck.py` by adding a threshold check to ensure that push parameters are meaningful before requiring related data options.
* Fixed logic in `pth2json.py` to correctly update the `freeze` and `push` options when converting to the no-overlap version, preventing potential configuration errors.

### Checkpoint management

* Cleaned up redundant code in the checkpoint deletion logic within the `iteration` method of `saver.py`, ensuring only one block handles checkpoint queue overflow.[Copilot is generating a summary...]…logic