### PR TITLE
feat: Support SOC for overlap, add --soc option in esk, add uniform_noref method for SOC and support s/p/d type for SOC

### DIFF
--- a/dptb/entrypoints/emp_sk.py
+++ b/dptb/entrypoints/emp_sk.py
@@ -8,12 +8,14 @@ import re
 import os
 from dptb.utils.gen_inputs import gen_inputs
 import json
+from collections import OrderedDict
 log = logging.getLogger(__name__)
 
 def to_empsk(
     INPUT,
     output='./', 
     basemodel='poly2',
+    soc= None,
     **kwargs):
     """
     Convert the model to empirical SK parameters.
@@ -23,7 +25,7 @@ def to_empsk(
     with open(INPUT, 'r') as f:
         input = json.load(f)
     common_options = input['common_options']
-    EmpSK(common_options, basemodel=basemodel).to_json(outdir=output)
+    EmpSK(common_options, basemodel=basemodel).to_json(outdir=output, soc=soc)
 
 class EmpSK(object):
     """
@@ -45,17 +47,56 @@ class EmpSK(object):
 
         self.model = build_model(model_ckpt, common_options=common_options, no_check=True)
 
-    def to_json(self, outdir='./'):
+    def to_json(self, outdir='./', soc=None):
         """
         Convert the model to json format.
         """
         # 判断是否存在输出目录
         if not os.path.exists(outdir):
             os.makedirs(outdir, exist_ok=True)
-        json_dict = self.model.to_json(basisref=self.basisref)
-        with open(os.path.join(outdir,'sktb.json'), 'w') as f:
-            json.dump(json_dict, f, indent=4)
+        json_dict = self.model.to_json(basisref=self.basisref)\
         
+        if soc is not None:
+            mp = json_dict.setdefault("model_params", {})
+            onsite = mp.get("onsite", {})
+
+            # build soc block based on onsite
+            soc_block = {}
+            for key, val in onsite.items():
+                parts = key.split("-")
+                if len(parts) < 3:
+                    continue
+                elem, orb = parts[0], parts[1]
+                # s and * orbitals -> 0, others -> soc value
+                if orb.lower() == "s" or "*" in orb:
+                    v = 0.0
+                else:
+                    v = float(soc)
+                soc_block[key] = [v]
+
+            # insert soc block after overlap
+            if isinstance(mp, dict):
+                new_mp = OrderedDict()
+                inserted = False
+                for k, v in mp.items():
+                    new_mp[k] = v
+                    if k == "overlap":
+                        new_mp["soc"] = soc_block
+                        inserted = True
+                if not inserted:
+                    new_mp["soc"] = soc_block
+                json_dict["model_params"] = new_mp
+
+            # update model_options for nnsk.soc.method
+            mo = json_dict.setdefault("model_options", {})
+            nnsk = mo.setdefault("nnsk", {})
+            soc_opt = nnsk.setdefault("soc", {})
+            soc_opt["method"] = "uniform_noref"
+
+        # write final file
+        with open(os.path.join(outdir, 'sktb.json'), 'w') as f:
+            json.dump(json_dict, f, indent=4)
+
         # save input template
         # input_template = gen_inputs(model=self.model, task='train', mode=mode)
         

--- a/dptb/entrypoints/main.py
+++ b/dptb/entrypoints/main.py
@@ -203,12 +203,6 @@ def main_parser() -> argparse.ArgumentParser:
         help="The pth ckpt to be transfered to json.",
     )
     parser_pth2json.add_argument(
-        "-dels", 
-        "--deleteoverlap",
-        help="Transfer to no overlap version.",
-        action="store_true"
-    )
-    parser_pth2json.add_argument(
         "-o",
         "--outdir",
         type=str,
@@ -434,6 +428,14 @@ def main_parser() -> argparse.ArgumentParser:
         type=str,
         default="poly2",
         help="The base model type can be poly2 or poly4."
+    )
+    parser_esk.add_argument(
+        "--soc",
+        "--soc_onsite",
+        nargs="?", 
+        const=0.2, 
+        type=float,
+        help="Enable SOC, default 0.2 if no value is given. Example: --soc or --soc=0.5"
     )
     return parser
 

--- a/dptb/entrypoints/main.py
+++ b/dptb/entrypoints/main.py
@@ -203,6 +203,12 @@ def main_parser() -> argparse.ArgumentParser:
         help="The pth ckpt to be transfered to json.",
     )
     parser_pth2json.add_argument(
+        "-dels", 
+        "--deleteoverlap",
+        help="Transfer to no overlap version.",
+        action="store_true"
+    )
+    parser_pth2json.add_argument(
         "-o",
         "--outdir",
         type=str,

--- a/dptb/nn/hr2hk.py
+++ b/dptb/nn/hr2hk.py
@@ -171,7 +171,6 @@ class HR2HK(torch.nn.Module):
         
         if soc:
             if self.overlap:
-                print("Overlap for SOC is realized by kronecker product.")
                 # ========== S_soc = S ⊗ I₂ : N×N S(k) to 2N×2N kronecker product ==========
                 S_soc = torch.zeros(kpoints.shape[0], 2*all_norb, 2*all_norb, dtype=self.ctype, device=self.device)
                 S_soc[:, :all_norb, :all_norb] = block

--- a/dptb/nn/nnsk.py
+++ b/dptb/nn/nnsk.py
@@ -132,7 +132,6 @@ class NNSK(torch.nn.Module):
                 soc_param = torch.empty([len(self.idp_sk.type_names), self.idp_sk.n_onsite_socLs, self.soc_fn.num_paras], dtype=self.dtype, device=self.device)
                 nn.init.normal_(soc_param, mean=0.0, std=std)
                 self.soc_param = torch.nn.Parameter(soc_param)
-                print(self.soc_param)
             else:
                 raise NotImplementedError(f"The soc method {self.soc_options['method']} is not implemented.")
 

--- a/dptb/nn/nnsk.py
+++ b/dptb/nn/nnsk.py
@@ -132,6 +132,7 @@ class NNSK(torch.nn.Module):
                 soc_param = torch.empty([len(self.idp_sk.type_names), self.idp_sk.n_onsite_socLs, self.soc_fn.num_paras], dtype=self.dtype, device=self.device)
                 nn.init.normal_(soc_param, mean=0.0, std=std)
                 self.soc_param = torch.nn.Parameter(soc_param)
+                print(self.soc_param)
             else:
                 raise NotImplementedError(f"The soc method {self.soc_options['method']} is not implemented.")
 
@@ -979,6 +980,22 @@ class NNSK(torch.nn.Module):
                 to_uniform = True
             else:
                 print("The basisref is not used. since the onsite method is not uniform_noref.")
+        # add the support for soc uniform_noref when use ['s', 'p', 'd', 'f'] in soc case 
+        if basisref is not None:
+            if  self.model_options['nnsk']['soc']['method'] in ['uniform_noref']:
+                for atom, orb in self.basis.items():
+                    new_basis[atom] = []
+                    if atom not in basisref:
+                        raise ValueError("The atom in the model basis should be in the basisref.")
+                    for o in orb:
+                        if o not in ['s', 'p', 'd', 'f']:
+                            raise ValueError("For uniform_noref mode, the orb in the model basis should be in ['s', 'p', 'd', 'f'].")
+                        if o not in list(basisref[atom].keys()):
+                            raise ValueError("The orb in the model basis should be in the basisref.")
+                        new_basis[atom].append(basisref[atom][o]) 
+            else:
+                print("The basisref is not used. since the soc method is not uniform_noref.")
+
 
         ckpt = {}
         # load hopping params

--- a/dptb/nn/sktb/soc.py
+++ b/dptb/nn/sktb/soc.py
@@ -27,6 +27,7 @@ class BaseSOC(ABC):
 class SOCFormula(BaseSOC):
     num_paras_dict = {
         'uniform': 1,
+        'uniform_noref': 1,
         "none": 0,
         "custom": None,
     }
@@ -42,6 +43,8 @@ class SOCFormula(BaseSOC):
             pass
         elif functype == 'uniform':
             assert hasattr(self, 'uniform')
+        elif functype == 'uniform_noref':
+            assert hasattr(self, 'uniform_noref')
         elif functype == 'custom':
             assert hasattr(self, 'custom')
         else:
@@ -64,6 +67,8 @@ class SOCFormula(BaseSOC):
             return self.none(**kwargs)
         elif self.functype == 'uniform':
             return self.uniform(**kwargs)
+        elif self.functype == 'uniform_noref':
+            return self.uniform_noref(**kwargs)
         elif self.functype == 'custom':
             return self.custom(**kwargs)
         else:
@@ -114,4 +119,26 @@ class SOCFormula(BaseSOC):
         idx = self.idp.transform_atom(atomic_numbers)
 
         return nn_soc_paras[idx] + self.none(atomic_numbers=atomic_numbers)
-        
+
+    def uniform_noref(self, atomic_numbers: torch.Tensor, nn_soc_paras: torch.Tensor, **kwargs):
+        """The uniform soc function with no reference , that have the same onsite energies for one specific orbital of a atom type.
+
+        Parameters
+        ----------
+        atomic_numbers : torch.Tensor(N) or torch.Tensor(N,1)
+            The atomic number list.
+        nn_onsite_paras : torch.Tensor(N_atom_type, n_orb)
+            The nn fitted parameters for onsite energies.
+
+        Returns
+        -------
+        torch.Tensor(N, n_orb)
+            the onsite energies by composing results from nn and ones from database.
+        """
+        atomic_numbers = atomic_numbers.reshape(-1)
+        if nn_soc_paras.shape[-1] == 1:
+            nn_soc_paras = nn_soc_paras.squeeze(-1)
+
+        idx = self.idp.transform_atom(atomic_numbers)
+
+        return nn_soc_paras[idx]


### PR DESCRIPTION
This pull request introduces comprehensive **Spin-Orbit Coupling (SOC) support** into the overlap SK build. It adds new CLI functionality, improves JSON export, and enhances model configuration to make SOC handling robust and user-friendly. The most important changes are grouped below.


This pull request introduces several improvements related to **Spin-Orbit Coupling (SOC)** handling and model export in DeePTB. The most important changes are grouped below.

### 1. SOC support for overlap
* The `hr2hk` module did not implement SOC support when overlap was enabled. This made it raise an error of `Overlap is not implemented for SOC` when perform training with both SOC and overlap simultaneously.

* **Implementation:**

  * Implemented SOC-overlap coupling as:      `S_soc = S ⊗ I₂` , transforming the $N \times N$ overlap matrix $S(k)$ into a $2N \times 2N$ Kronecker product form.
  * Enforced a strict Hermitian form on the overlap matrix to avoid numerical issues preventing runtime errors . **It can be bypassed by setting `"freeze": ["overlap"]`**, otherwise it will throw an error out when SOC+overlap is active and `"overlap"` is not frozen, like:

    ```text
    torch._C._LinAlgError: linalg.cholesky: ... not positive definite
    ```


* **Now:**
  Verified training with SOC+overlap is now stable on **MoS₂** benchmarks, confirming correct functionality of the new implementation. Results as below:
<img width="480" height="420" alt="image" src="https://github.com/user-attachments/assets/fd0166a5-5445-4533-aa84-fb15578a8c09" />


### 2. New `--soc` option in `dptb esk` to get an easy start for soc training

* Added a `--soc` option to the `dptb esk` command.
  * The soc block is derived from the `onsite` section for schema consistency.
  * SOC on different orbitals:
    * `"s"` orbitals and orbitals containing `"*"` → `0`
    * `"p"` and `"d"` orbitals → SOC value (default is 0.2).
* Updated `model_options.nnsk.soc.method` to `"uniform_noref"` when SOC is enabled.

### 3. New SOC method: `uniform_noref`, add `"s"`, `"p"`, `"d"` orbital support to soc in `nnsk`.
* Introduced `"uniform_noref"` as a optional SOC method name.
* When training with soc, it didn't recognize basis writen as ["s","p","d"]. So I realize the  `"uniform_noref"`  method for  `"soc"`  just as it was implemented in `"onsite"`.


