### PR TITLE
Fix: fix AtomicData.py mask handling and ensure proper numpy arrays

### DIFF
--- a/dptb/data/AtomicData.py
+++ b/dptb/data/AtomicData.py
@@ -1014,7 +1014,7 @@ def neighbor_list_and_relative_vec(
     mask[first_idex == second_idex] = False
     # get index bool type ~mask  for i == j.
     # Convert mask to numpy for consistent indexing behavior
-    mask_np = mask.numpy()
+    mask_np = mask.cpu().numpy()
     o_first_idex = first_idex[~mask_np]
     o_second_idex = second_idex[~mask_np]
     o_shift = shifts[~mask_np]
@@ -1050,7 +1050,7 @@ def neighbor_list_and_relative_vec(
     del o_mask
 
     # Convert mask to numpy for indexing numpy arrays (avoids torch/numpy compatibility issues)
-    mask_np = mask.numpy()
+    mask_np = mask.cpu().numpy()
     first_idex = torch.as_tensor(first_idex[mask_np], dtype=torch.long, device=out_device)
     second_idex = torch.as_tensor(second_idex[mask_np], dtype=torch.long, device=out_device)
     shifts = torch.as_tensor(shifts[mask_np], dtype=out_dtype, device=out_device)


### PR DESCRIPTION
For issue #285 , I fix potential problems in AtomicData.py when treating isolated systems when `self_interaction=False`.
1. Convert the mask to a numpy array for consistent indexing
2. Ensure that all output arrays are proper numpy arrays to avoid compatibility issues in isolated systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal data handling for atomic systems: more robust indexing and reshaping for isolated/self-interaction cases, and safer device-aware conversions to ensure compatibility and correctness across edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->