### PR TITLE
fix: Ensure proper tensor conversion for numpy solver in Eigenvalues …

### DIFF
--- a/dptb/nn/energy.py
+++ b/dptb/nn/energy.py
@@ -83,6 +83,7 @@ class Eigenvalues(nn.Module):
         for i in range(int(np.ceil(num_k / nk))):
             data[AtomicDataDict.KPOINT_KEY] = kpoints[i*nk:(i+1)*nk]
             data = self.h2k(data)
+            h_transformed_np = None
             if self.overlap:
                 data = self.s2k(data)
                 if eig_solver == 'torch':
@@ -99,6 +100,8 @@ class Eigenvalues(nn.Module):
             if eig_solver == 'torch':
                 eigvals.append(torch.linalg.eigvalsh(data[self.h_out_field]))
             elif eig_solver == 'numpy':
+                if h_transformed_np is None:
+                    h_transformed_np = data[self.h_out_field].detach().cpu().numpy()
                 eigvals_np = np.linalg.eigvalsh(a=h_transformed_np)
                 # Preserve dtype by converting to the Hamiltonian's original dtype
                 eigvals.append(torch.from_numpy(eigvals_np).to(dtype=self.h2k.dtype, device=self.h2k.device))


### PR DESCRIPTION
This pull request updates the `forward` method in `dptb/nn/energy.py` to improve compatibility and correctness when using the numpy eigenvalue solver, especially when working with tensors on different devices and data types. The main changes ensure that all tensors are moved to the CPU before being converted to numpy arrays and that the output eigenvalues preserve the original data type. For #275. 

Key changes:

**Device and dtype handling improvements:**

* Ensured that tensors are moved to the CPU before conversion to numpy when using the numpy eigenvalue solver, preventing device mismatch errors.
* When converting eigenvalues computed via numpy back to torch tensors, the dtype is now explicitly matched to the original Hamiltonian's dtype, preserving numerical consistency.

**Code clarity and correctness:**

* Added logic to handle the case when the numpy solver is used without overlap, ensuring proper conversion to numpy arrays.…class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed eigenvalue computation with the NumPy solver when overlap is present, preventing unintended in-place modifications that could corrupt results.
  * Ensured NumPy-based calculations run on the CPU and return results without losing numerical precision.
  * Preserved original data types and device alignment so NumPy and Torch code paths produce consistent, stable eigenvalues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->