### PR TITLE
Fix(postprocess): Fixed overlap data initialization in electronic structure calculations Bug due to merged PR300

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+debug_**
 test*.ipynb
 examples/**/*centres.xyz
 examples/**/*.win

--- a/dptb/postprocess/elec_struc_cal.py
+++ b/dptb/postprocess/elec_struc_cal.py
@@ -96,6 +96,16 @@ class ElecStruCal(object):
             the loaded AtomicData object.
         
         '''
+        if override_overlap is not None:
+            if not self.overlap:
+                self.eigv = Eigenvalues(
+                    idp=self.model.idp,
+                    device=self.device,
+                    s_edge_field=AtomicDataDict.EDGE_OVERLAP_KEY,
+                    s_node_field=AtomicDataDict.NODE_OVERLAP_KEY,
+                    s_out_field=AtomicDataDict.OVERLAP_KEY,
+                    dtype=self.model.dtype,
+                )
         return load_data_for_model(
             data=data,
             model=self.model,


### PR DESCRIPTION
Add support for overriding overlap calculations in the ElecStruCal class when override_overlap parameter is provided. This allows for more flexible control over eigenvalue calculations by enabling overlap matrix initialization when needed. Also updated .gitignore to exclude debug files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed overlap data initialization in electronic structure calculations to ensure proper handling when override parameters are provided.

* **Chores**
  * Updated build configuration ignore patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->