### PR TITLE
build(pyproject): adopt PEP 639 license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ keywords = ["deep learning", "tight-binding", "electronic structure", "physics"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "dptb"
 dynamic = ["version"]
 description = "A unified deep learning package for electronic structure models including tight-binding, KS Hamiltonian and density matrix models"
 readme = "README.md"
-license = {text = "LGPL-3.0"}
+license = "LGPL-3.0-or-later"
+license-files = ["LICENSE"]
 requires-python = ">=3.9,<=3.12.9"
 authors = [
     {name = "DeePTB Team"}
@@ -60,7 +61,7 @@ Repository = "https://github.com/deepmodeling/DeePTB"
 Documentation = "https://deeptb.readthedocs.io"
 
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm>=8"]
+requires = ["setuptools>=77.0.3", "setuptools>=77.0.3-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "dptb"
 dynamic = ["version"]
 description = "A unified deep learning package for electronic structure models including tight-binding, KS Hamiltonian and density matrix models"
 readme = "README.md"
-license = "LGPL-3.0-or-later"
+license = "LGPL-3.0-only"
 license-files = ["LICENSE"]
 requires-python = ">=3.9,<=3.12.9"
 authors = [
@@ -60,7 +60,7 @@ Repository = "https://github.com/deepmodeling/DeePTB"
 Documentation = "https://deeptb.readthedocs.io"
 
 [build-system]
-requires = ["setuptools>=77.0.3", "setuptools>=77.0.3-scm>=8"]
+requires = ["setuptools>=77.0.3", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
This PR replaces and fixes #323.

## Summary

- Adopt PEP 639 license metadata in `pyproject.toml`.
- Add `license-files = ["LICENSE"]` so the license file is included in package metadata.
- Remove the deprecated license classifier.
- Require `setuptools>=77.0.3`, which supports PEP 639 metadata.
- Keep `setuptools-scm>=8` unchanged and valid.

## Notes

The original PR accidentally changed the build requirement to `setuptools>=77.0.3-scm>=8`, which is not a valid version specifier and caused CI metadata generation to fail.

This PR also uses `LGPL-3.0-only` instead of `LGPL-3.0-or-later` to keep the SPDX metadata conservative and equivalent to the previous LGPL v3 metadata.

## Validation

- `uv build`

The build completed successfully and included the license file in the package metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * License metadata standardized to industry-standard SPDX format for improved clarity and compliance

* **Chores**
  * Build system requirements updated for enhanced stability and compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepmodeling/DeePTB/pull/333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->