### PR TITLE
fix(postprocess): normalize unified eigen solver options

### DIFF
--- a/dptb/postprocess/unified/calculator.py
+++ b/dptb/postprocess/unified/calculator.py
@@ -59,12 +59,17 @@ class HamiltonianCalculator(ABC):
         pass
         
     @abstractmethod
-    def get_eigenvalues(self, atomic_data: dict) -> Tuple[dict, torch.Tensor]:
+    def get_eigenvalues(
+        self,
+        atomic_data: dict,
+        **kwargs,
+    ) -> Tuple[dict, torch.Tensor]:
         """
         Calculate eigenvalues for the given atomic data.
         
         Args:
             atomic_data: The input atomic data dictionary.
+            **kwargs: Implementation-specific eigenvalue solver options.
             
         Returns:
             A tuple containing the updated atomic data and the eigenvalues tensor.
@@ -72,12 +77,17 @@ class HamiltonianCalculator(ABC):
         pass
     
     @abstractmethod
-    def get_eigenstates(self, atomic_data: dict) -> Tuple[dict, torch.Tensor, torch.Tensor]:
+    def get_eigenstates(
+        self,
+        atomic_data: dict,
+        **kwargs,
+    ) -> Tuple[dict, torch.Tensor, torch.Tensor]:
         """
         Calculate eigenvalues and eigenvectors.
         
         Args:
             atomic_data: The input atomic data dictionary.
+            **kwargs: Implementation-specific eigenstate solver options.
             
         Returns:
             Tuple of (updated atomic_data, eigenvalues, eigenvectors).

--- a/dptb/postprocess/unified/properties/band.py
+++ b/dptb/postprocess/unified/properties/band.py
@@ -223,6 +223,7 @@ class BandAccessor:
         
     def compute(
         self,
+        nk: Optional[int] = None,
         solver: Optional[str] = None,
         ill_threshold: Optional[float] = None,
         ill_pad_value: float = 1e4,
@@ -239,6 +240,7 @@ class BandAccessor:
         # Calculate
         data, eigs = self._system.calculator.get_eigenvalues(
             data,
+            nk=nk,
             solver=solver,
             ill_threshold=ill_threshold,
             ill_pad_value=ill_pad_value,

--- a/dptb/postprocess/unified/properties/dos.py
+++ b/dptb/postprocess/unified/properties/dos.py
@@ -155,7 +155,7 @@ class DosAccessor:
         nk: Optional[int] = None,
         solver: Optional[str] = None,
         ill_threshold: Optional[float] = None,
-        ill_pad_value: float = 1e4,
+        ill_pad_value: Optional[float] = None,
     ):
         """
         Calculate DOS based on the stored configuration.
@@ -176,6 +176,8 @@ class DosAccessor:
                 log.warning("solver is ignored for PDOS because eigenvector solver selection is not implemented.")
             if ill_threshold is not None:
                 log.warning("ill_threshold is ignored for PDOS because eigenvector fallback is not implemented.")
+            if ill_pad_value is not None:
+                log.warning("ill_pad_value is ignored for PDOS because eigenvector padding is not implemented.")
             data, eigs, vecs = self._system.calculator.get_eigenstates(data, nk=nk)
             # vecs: [Nk, Norb, Norb] (assuming 1 batch)
             # eigs: [Nk, Norb]
@@ -199,7 +201,7 @@ class DosAccessor:
                 nk=nk,
                 solver=solver,
                 ill_threshold=ill_threshold,
-                ill_pad_value=ill_pad_value,
+                ill_pad_value=1e4 if ill_pad_value is None else ill_pad_value,
             )
             vecs = None
         

--- a/dptb/postprocess/unified/properties/dos.py
+++ b/dptb/postprocess/unified/properties/dos.py
@@ -152,6 +152,7 @@ class DosAccessor:
 
     def compute(
         self,
+        nk: Optional[int] = None,
         solver: Optional[str] = None,
         ill_threshold: Optional[float] = None,
         ill_pad_value: float = 1e4,
@@ -171,9 +172,11 @@ class DosAccessor:
         calc_pdos = self._config.get('pdos', False)
         
         if calc_pdos:
+            if solver is not None:
+                log.warning("solver is ignored for PDOS because eigenvector solver selection is not implemented.")
             if ill_threshold is not None:
                 log.warning("ill_threshold is ignored for PDOS because eigenvector fallback is not implemented.")
-            data, eigs, vecs = self._system.calculator.get_eigenstates(data)
+            data, eigs, vecs = self._system.calculator.get_eigenstates(data, nk=nk)
             # vecs: [Nk, Norb, Norb] (assuming 1 batch)
             # eigs: [Nk, Norb]
             
@@ -193,6 +196,7 @@ class DosAccessor:
         else:
             data, eigs = self._system.calculator.get_eigenvalues(
                 data,
+                nk=nk,
                 solver=solver,
                 ill_threshold=ill_threshold,
                 ill_pad_value=ill_pad_value,

--- a/dptb/postprocess/unified/system.py
+++ b/dptb/postprocess/unified/system.py
@@ -60,6 +60,27 @@ class TBSystem:
         
         self._atomic_data = self.set_atoms(data, override_overlap)
 
+    @staticmethod
+    def _pop_solver_kwargs(kwargs: dict, context: str) -> dict:
+        solver = kwargs.pop("solver", None)
+        eig_solver = kwargs.pop("eig_solver", None)
+        if solver is not None and eig_solver is not None and solver != eig_solver:
+            raise ValueError(
+                f"solver and eig_solver were both provided to {context} with different values: "
+                f"{solver!r} != {eig_solver!r}."
+            )
+        if solver is None and eig_solver is not None:
+            log.warning("eig_solver is accepted for compatibility in %s; prefer solver.", context)
+            solver = eig_solver
+
+        solver_kwargs = {}
+        if solver is not None:
+            solver_kwargs["solver"] = solver
+        for key in ("nk", "ill_threshold", "ill_pad_value"):
+            if key in kwargs:
+                solver_kwargs[key] = kwargs.pop(key)
+        return solver_kwargs
+
     @property
     def calculator(self) -> HamiltonianCalculator:
         """Access the calculator."""
@@ -234,11 +255,7 @@ class TBSystem:
                          q_tol: float = 1e-5,
                          **kwargs):
         # get efermi from scratch.
-        solver_kwargs = {
-            key: kwargs.pop(key)
-            for key in ("nk", "solver", "ill_threshold", "ill_pad_value")
-            if key in kwargs
-        }
+        solver_kwargs = self._pop_solver_kwargs(kwargs, "TBSystem.get_efermi")
         efermi_kwargs = {
             key: kwargs.pop(key)
             for key in ("k_weights",)
@@ -318,20 +335,25 @@ class TBSystem:
     def get_bands(self, kpath_config: Optional[dict] = None, reuse: Optional[bool]=True, **kwargs):
         # 计算能带，返回 bands
         # bands 应该是一个类，也有属性。bands.kpoints, bands.eigenvalues, bands.klabels, bands.kticks, 也有函数 bands.plot()
-        if self.has_bands and reuse:
+        solver_kwargs = self._pop_solver_kwargs(kwargs, "TBSystem.get_bands")
+        if kwargs:
+            log.warning(f"Ignoring unsupported get_bands options: {sorted(kwargs)}")
+
+        if (
+            self.has_bands
+            and reuse
+            and getattr(self, "_last_band_solver_kwargs", None) == solver_kwargs
+        ):
             return self._bands
         else:
-            assert kpath_config is not None, "kpath_config must be provided if bands not calculated."
-            solver_kwargs = {
-                key: kwargs.pop(key)
-                for key in ("solver", "ill_threshold", "ill_pad_value")
-                if key in kwargs
-            }
-            if kwargs:
-                log.warning(f"Ignoring unsupported get_bands options: {sorted(kwargs)}")
-            self._bands = BandAccessor(self)
-            self._bands.set_kpath(**kpath_config)
+            if not (self.has_bands and reuse):
+                assert kpath_config is not None, "kpath_config must be provided if bands not calculated."
+                self._bands = BandAccessor(self)
+                self._bands.set_kpath(**kpath_config)
+            elif kpath_config is not None:
+                self._bands.set_kpath(**kpath_config)
             self._bands.compute(**solver_kwargs)
+            self._last_band_solver_kwargs = dict(solver_kwargs)
             self.has_bands = True
             return self._bands
 
@@ -347,11 +369,7 @@ class TBSystem:
             return  self._dos
         else:
             assert kmesh is not None, "kmesh must be provided."
-            solver_kwargs = {
-                key: kwargs.pop(key)
-                for key in ("solver", "ill_threshold", "ill_pad_value")
-                if key in kwargs
-            }
+            solver_kwargs = self._pop_solver_kwargs(kwargs, "TBSystem.get_dos")
             self._dos = DosAccessor(self)
             self._dos.set_kpoints(kmesh=kmesh,is_gamma_center=is_gamma_center)
             self._dos.set_dos_config(erange=erange, npts=npts, smearing=smearing, sigma=sigma, pdos=pdos, **kwargs)

--- a/dptb/postprocess/unified/system.py
+++ b/dptb/postprocess/unified/system.py
@@ -81,6 +81,63 @@ class TBSystem:
                 solver_kwargs[key] = kwargs.pop(key)
         return solver_kwargs
 
+    @staticmethod
+    def _eigen_cache_key(solver_kwargs: dict) -> dict:
+        return {key: value for key, value in solver_kwargs.items() if key != "nk"}
+
+    @classmethod
+    def _normalize_cache_value(cls, value):
+        if isinstance(value, np.ndarray):
+            return cls._normalize_cache_value(value.tolist())
+        if isinstance(value, dict):
+            return tuple(
+                (key, cls._normalize_cache_value(item))
+                for key, item in sorted(value.items())
+            )
+        if isinstance(value, (list, tuple)):
+            return tuple(cls._normalize_cache_value(item) for item in value)
+        return value
+
+    @staticmethod
+    def _cache_matches(last_key: Optional[dict], requested_key: dict) -> bool:
+        if last_key is None:
+            return False
+        return all(last_key.get(key) == value for key, value in requested_key.items())
+
+    @classmethod
+    def _band_cache_key(cls, solver_kwargs: dict, kpath_config: Optional[dict] = None) -> dict:
+        cache_key = {"solver": cls._eigen_cache_key(solver_kwargs)}
+        if kpath_config is not None:
+            cache_key["kpath_config"] = cls._normalize_cache_value(kpath_config)
+        return cache_key
+
+    @classmethod
+    def _dos_cache_key(
+        cls,
+        solver_kwargs: dict,
+        kmesh: Optional[Union[list, np.ndarray]] = None,
+        is_gamma_center: Optional[bool] = True,
+        erange: Optional[Union[list, np.ndarray]] = None,
+        npts: Optional[int] = 100,
+        smearing: Optional[str] = 'gaussian',
+        sigma: Optional[float] = 0.05,
+        pdos: Optional[bool] = False,
+        extra_kwargs: Optional[dict] = None,
+    ) -> dict:
+        cache_key = {"solver": cls._eigen_cache_key(solver_kwargs)}
+        if kmesh is not None:
+            cache_key["dos_config"] = cls._normalize_cache_value({
+                "kmesh": kmesh,
+                "is_gamma_center": is_gamma_center,
+                "erange": erange,
+                "npts": npts,
+                "smearing": smearing,
+                "sigma": sigma,
+                "pdos": pdos,
+                "extra_kwargs": extra_kwargs or {},
+            })
+        return cache_key
+
     @property
     def calculator(self) -> HamiltonianCalculator:
         """Access the calculator."""
@@ -336,13 +393,14 @@ class TBSystem:
         # 计算能带，返回 bands
         # bands 应该是一个类，也有属性。bands.kpoints, bands.eigenvalues, bands.klabels, bands.kticks, 也有函数 bands.plot()
         solver_kwargs = self._pop_solver_kwargs(kwargs, "TBSystem.get_bands")
+        cache_key = self._band_cache_key(solver_kwargs, kpath_config)
         if kwargs:
             log.warning(f"Ignoring unsupported get_bands options: {sorted(kwargs)}")
 
         if (
             self.has_bands
             and reuse
-            and getattr(self, "_last_band_solver_kwargs", None) == solver_kwargs
+            and self._cache_matches(getattr(self, "_last_band_cache_key", None), cache_key)
         ):
             return self._bands
         else:
@@ -353,7 +411,7 @@ class TBSystem:
             elif kpath_config is not None:
                 self._bands.set_kpath(**kpath_config)
             self._bands.compute(**solver_kwargs)
-            self._last_band_solver_kwargs = dict(solver_kwargs)
+            self._last_band_cache_key = self._band_cache_key(solver_kwargs, kpath_config)
             self.has_bands = True
             return self._bands
 
@@ -365,15 +423,41 @@ class TBSystem:
         """
         # 计算态密度，返回 dos
         # dos 应该是一个类，也有属性。dos.kmesh, dos.eigenvalues, dos.klabels, dos.kticks, 也有函数 dos.plot()
-        if self.has_dos and reuse:
+        solver_kwargs = self._pop_solver_kwargs(kwargs, "TBSystem.get_dos")
+        cache_key = self._dos_cache_key(
+            solver_kwargs=solver_kwargs,
+            kmesh=kmesh,
+            is_gamma_center=is_gamma_center,
+            erange=erange,
+            npts=npts,
+            smearing=smearing,
+            sigma=sigma,
+            pdos=pdos,
+            extra_kwargs=kwargs,
+        )
+        if (
+            self.has_dos
+            and reuse
+            and self._cache_matches(getattr(self, "_last_dos_cache_key", None), cache_key)
+        ):
             return  self._dos
         else:
             assert kmesh is not None, "kmesh must be provided."
-            solver_kwargs = self._pop_solver_kwargs(kwargs, "TBSystem.get_dos")
             self._dos = DosAccessor(self)
             self._dos.set_kpoints(kmesh=kmesh,is_gamma_center=is_gamma_center)
             self._dos.set_dos_config(erange=erange, npts=npts, smearing=smearing, sigma=sigma, pdos=pdos, **kwargs)
             self._dos.compute(**solver_kwargs)
+            self._last_dos_cache_key = self._dos_cache_key(
+                solver_kwargs=solver_kwargs,
+                kmesh=kmesh,
+                is_gamma_center=is_gamma_center,
+                erange=erange,
+                npts=npts,
+                smearing=smearing,
+                sigma=sigma,
+                pdos=pdos,
+                extra_kwargs=kwargs,
+            )
             self.has_dos = True
             return self._dos
 

--- a/dptb/postprocess/unified/system.py
+++ b/dptb/postprocess/unified/system.py
@@ -124,9 +124,9 @@ class TBSystem:
         pdos: Optional[bool] = False,
         extra_kwargs: Optional[dict] = None,
     ) -> dict:
-        cache_key = {"solver": cls._eigen_cache_key(solver_kwargs)}
-        if kmesh is not None:
-            cache_key["dos_config"] = cls._normalize_cache_value({
+        return {
+            "solver": cls._eigen_cache_key(solver_kwargs),
+            "dos_config": cls._normalize_cache_value({
                 "kmesh": kmesh,
                 "is_gamma_center": is_gamma_center,
                 "erange": erange,
@@ -135,8 +135,8 @@ class TBSystem:
                 "sigma": sigma,
                 "pdos": pdos,
                 "extra_kwargs": extra_kwargs or {},
-            })
-        return cache_key
+            }),
+        }
 
     @property
     def calculator(self) -> HamiltonianCalculator:

--- a/dptb/tests/test_postprocess_unified.py
+++ b/dptb/tests/test_postprocess_unified.py
@@ -122,6 +122,68 @@ def test_get_efermi_accepts_solver_kwargs(silicon_system):
     efermi = silicon_system.get_efermi(kmesh=[2, 2, 2], solver="torch")
     assert np.isfinite(efermi)
 
+def test_get_efermi_accepts_eig_solver_alias(silicon_system):
+    silicon_system.set_electrons({"Si": 4})
+    efermi = silicon_system.get_efermi(kmesh=[2, 2, 2], eig_solver="torch", nk=2)
+    assert np.isfinite(efermi)
+
+def test_get_bands_forwards_nk_and_eig_solver_alias(silicon_system, monkeypatch):
+    captured = {}
+
+    def fake_get_eigenvalues(data, **kwargs):
+        captured.update(kwargs)
+        kpoints = data[AtomicDataDict.KPOINT_KEY]
+        num_k = kpoints[0].shape[0] if kpoints.is_nested else kpoints.shape[0]
+        num_orb = len(silicon_system.atom_orbs)
+        eigs = torch.zeros((num_k, num_orb), dtype=silicon_system.calculator.dtype)
+        return data, eigs
+
+    monkeypatch.setattr(silicon_system.calculator, "get_eigenvalues", fake_get_eigenvalues)
+    bands = silicon_system.get_bands(
+        kpath_config={
+            "method": "abacus",
+            "kpath": [[0.0, 0.0, 0.0, 4], [0.5, 0.0, 0.5, 1]],
+            "klabels": ["G", "X"],
+        },
+        reuse=False,
+        eig_solver="torch",
+        nk=2,
+    )
+
+    assert isinstance(bands.band_data, BandStructureData)
+    assert captured["solver"] == "torch"
+    assert captured["nk"] == 2
+
+def test_get_dos_forwards_nk_and_eig_solver_alias(silicon_system, monkeypatch):
+    captured = {}
+
+    def fake_get_eigenvalues(data, **kwargs):
+        captured.update(kwargs)
+        kpoints = data[AtomicDataDict.KPOINT_KEY]
+        num_k = kpoints[0].shape[0] if kpoints.is_nested else kpoints.shape[0]
+        num_orb = len(silicon_system.atom_orbs)
+        eigs = torch.zeros((num_k, num_orb), dtype=silicon_system.calculator.dtype)
+        return data, eigs
+
+    monkeypatch.setattr(silicon_system.calculator, "get_eigenvalues", fake_get_eigenvalues)
+    dos = silicon_system.get_dos(
+        kmesh=[1, 1, 1],
+        erange=[-1, 1],
+        npts=10,
+        pdos=False,
+        reuse=False,
+        eig_solver="numpy",
+        nk=1,
+    )
+
+    assert isinstance(dos.dos_data, DosData)
+    assert captured["solver"] == "numpy"
+    assert captured["nk"] == 1
+
+def test_solver_and_eig_solver_conflict_raises(silicon_system):
+    with pytest.raises(ValueError, match="solver and eig_solver"):
+        silicon_system.get_bands(solver="torch", eig_solver="numpy")
+
 def test_get_hamiltonian_gethk(silicon_system):
     """Test getting Hamiltonian H(k) at specific k-points."""
     tbsys = silicon_system

--- a/dptb/tests/test_postprocess_unified.py
+++ b/dptb/tests/test_postprocess_unified.py
@@ -180,6 +180,137 @@ def test_get_dos_forwards_nk_and_eig_solver_alias(silicon_system, monkeypatch):
     assert captured["solver"] == "numpy"
     assert captured["nk"] == 1
 
+def test_get_dos_recomputes_when_solver_changes(silicon_system, monkeypatch):
+    calls = []
+
+    def fake_get_eigenvalues(data, **kwargs):
+        calls.append(dict(kwargs))
+        kpoints = data[AtomicDataDict.KPOINT_KEY]
+        num_k = kpoints[0].shape[0] if kpoints.is_nested else kpoints.shape[0]
+        num_orb = len(silicon_system.atom_orbs)
+        eigs = torch.zeros((num_k, num_orb), dtype=silicon_system.calculator.dtype)
+        return data, eigs
+
+    monkeypatch.setattr(silicon_system.calculator, "get_eigenvalues", fake_get_eigenvalues)
+
+    dos_kwargs = {
+        "kmesh": [1, 1, 1],
+        "erange": [-1, 1],
+        "npts": 10,
+        "pdos": False,
+    }
+    silicon_system.get_dos(**dos_kwargs, solver="torch", nk=1, reuse=False)
+    silicon_system.get_dos(**dos_kwargs, solver="numpy", nk=1)
+    silicon_system.get_dos(**dos_kwargs, solver="numpy", nk=2)
+
+    assert len(calls) == 2
+    assert calls[0]["solver"] == "torch"
+    assert calls[0]["nk"] == 1
+    assert calls[1]["solver"] == "numpy"
+    assert calls[1]["nk"] == 1
+
+def test_get_bands_reuses_when_only_nk_changes(silicon_system, monkeypatch):
+    calls = []
+
+    def fake_get_eigenvalues(data, **kwargs):
+        calls.append(dict(kwargs))
+        kpoints = data[AtomicDataDict.KPOINT_KEY]
+        num_k = kpoints[0].shape[0] if kpoints.is_nested else kpoints.shape[0]
+        num_orb = len(silicon_system.atom_orbs)
+        eigs = torch.zeros((num_k, num_orb), dtype=silicon_system.calculator.dtype)
+        return data, eigs
+
+    monkeypatch.setattr(silicon_system.calculator, "get_eigenvalues", fake_get_eigenvalues)
+    kpath_config = {
+        "method": "abacus",
+        "kpath": [[0.0, 0.0, 0.0, 4], [0.5, 0.0, 0.5, 1]],
+        "klabels": ["G", "X"],
+    }
+
+    silicon_system.get_bands(kpath_config=kpath_config, solver="torch", nk=1, reuse=False)
+    silicon_system.get_bands(kpath_config=kpath_config, solver="torch", nk=2)
+
+    assert len(calls) == 1
+    assert calls[0]["solver"] == "torch"
+    assert calls[0]["nk"] == 1
+
+def test_get_bands_recomputes_when_kpath_changes(silicon_system, monkeypatch):
+    calls = []
+
+    def fake_get_eigenvalues(data, **kwargs):
+        calls.append(dict(kwargs))
+        kpoints = data[AtomicDataDict.KPOINT_KEY]
+        num_k = kpoints[0].shape[0] if kpoints.is_nested else kpoints.shape[0]
+        num_orb = len(silicon_system.atom_orbs)
+        eigs = torch.zeros((num_k, num_orb), dtype=silicon_system.calculator.dtype)
+        return data, eigs
+
+    monkeypatch.setattr(silicon_system.calculator, "get_eigenvalues", fake_get_eigenvalues)
+    first_kpath = {
+        "method": "abacus",
+        "kpath": [[0.0, 0.0, 0.0, 4], [0.5, 0.0, 0.5, 1]],
+        "klabels": ["G", "X"],
+    }
+    second_kpath = {
+        "method": "abacus",
+        "kpath": [[0.0, 0.0, 0.0, 3], [0.5, 0.5, 0.0, 1]],
+        "klabels": ["G", "M"],
+    }
+
+    silicon_system.get_bands(kpath_config=first_kpath, solver="torch", nk=1, reuse=False)
+    silicon_system.get_bands(kpath_config=second_kpath, solver="torch", nk=2)
+
+    assert len(calls) == 2
+
+def test_get_dos_reuses_when_only_nk_changes(silicon_system, monkeypatch):
+    calls = []
+
+    def fake_get_eigenvalues(data, **kwargs):
+        calls.append(dict(kwargs))
+        kpoints = data[AtomicDataDict.KPOINT_KEY]
+        num_k = kpoints[0].shape[0] if kpoints.is_nested else kpoints.shape[0]
+        num_orb = len(silicon_system.atom_orbs)
+        eigs = torch.zeros((num_k, num_orb), dtype=silicon_system.calculator.dtype)
+        return data, eigs
+
+    monkeypatch.setattr(silicon_system.calculator, "get_eigenvalues", fake_get_eigenvalues)
+    dos_kwargs = {
+        "kmesh": [1, 1, 1],
+        "erange": [-1, 1],
+        "npts": 10,
+        "pdos": False,
+    }
+
+    silicon_system.get_dos(**dos_kwargs, solver="torch", nk=1, reuse=False)
+    silicon_system.get_dos(**dos_kwargs, solver="torch", nk=2)
+
+    assert len(calls) == 1
+    assert calls[0]["solver"] == "torch"
+    assert calls[0]["nk"] == 1
+
+def test_get_dos_recomputes_when_kmesh_changes(silicon_system, monkeypatch):
+    calls = []
+
+    def fake_get_eigenvalues(data, **kwargs):
+        calls.append(dict(kwargs))
+        kpoints = data[AtomicDataDict.KPOINT_KEY]
+        num_k = kpoints[0].shape[0] if kpoints.is_nested else kpoints.shape[0]
+        num_orb = len(silicon_system.atom_orbs)
+        eigs = torch.zeros((num_k, num_orb), dtype=silicon_system.calculator.dtype)
+        return data, eigs
+
+    monkeypatch.setattr(silicon_system.calculator, "get_eigenvalues", fake_get_eigenvalues)
+    dos_kwargs = {
+        "erange": [-1, 1],
+        "npts": 10,
+        "pdos": False,
+    }
+
+    silicon_system.get_dos(kmesh=[1, 1, 1], **dos_kwargs, solver="torch", nk=1, reuse=False)
+    silicon_system.get_dos(kmesh=[2, 1, 1], **dos_kwargs, solver="torch", nk=2)
+
+    assert len(calls) == 2
+
 def test_solver_and_eig_solver_conflict_raises(silicon_system):
     with pytest.raises(ValueError, match="solver and eig_solver"):
         silicon_system.get_bands(solver="torch", eig_solver="numpy")

--- a/dptb/tests/test_postprocess_unified.py
+++ b/dptb/tests/test_postprocess_unified.py
@@ -311,6 +311,37 @@ def test_get_dos_recomputes_when_kmesh_changes(silicon_system, monkeypatch):
 
     assert len(calls) == 2
 
+def test_get_dos_does_not_reuse_when_config_changes_without_kmesh(silicon_system, monkeypatch):
+    calls = []
+
+    def fake_get_eigenvalues(data, **kwargs):
+        calls.append(dict(kwargs))
+        kpoints = data[AtomicDataDict.KPOINT_KEY]
+        num_k = kpoints[0].shape[0] if kpoints.is_nested else kpoints.shape[0]
+        num_orb = len(silicon_system.atom_orbs)
+        eigs = torch.zeros((num_k, num_orb), dtype=silicon_system.calculator.dtype)
+        return data, eigs
+
+    monkeypatch.setattr(silicon_system.calculator, "get_eigenvalues", fake_get_eigenvalues)
+
+    silicon_system.get_dos(
+        kmesh=[1, 1, 1],
+        erange=[-1, 1],
+        npts=10,
+        pdos=False,
+        solver="torch",
+        reuse=False,
+    )
+    with pytest.raises(AssertionError, match="kmesh must be provided"):
+        silicon_system.get_dos(
+            erange=[-2, 2],
+            npts=10,
+            pdos=False,
+            solver="torch",
+        )
+
+    assert len(calls) == 1
+
 def test_solver_and_eig_solver_conflict_raises(silicon_system):
     with pytest.raises(ValueError, match="solver and eig_solver"):
         silicon_system.get_bands(solver="torch", eig_solver="numpy")


### PR DESCRIPTION
This PR extracts the still-useful part of #325 into a smaller change based on the current `main` branch.

Fixes #324.

## Summary

- Accept `eig_solver` as a compatibility alias in unified `TBSystem` APIs.
- Keep `solver` as the preferred unified API name.
- Raise `ValueError` if both `solver` and `eig_solver` are provided with different values.
- Forward `nk` through unified band and DOS eigenvalue calculations so users can control k-point chunking.
- Recompute cached band and DOS results when result-sensitive inputs change instead of returning stale cached data.
- Keep `nk` out of cache invalidation because it only controls k-point chunking and does not change the sampled k-points or numerical result.

## Notes

The legacy APIs and run configs still use `eig_solver`; the unified `TBSystem` layer now accepts it for migration compatibility and normalizes it internally to `solver` before calling the lower-level eigenvalue code.

This intentionally does not include the `override_overlap` changes from #325. Current `main` already has per-call `override_overlap` support with newer overlap/eigensolver handling, while #325's instance-level default/opt-out approach adds extra state semantics and should not be carried into this focused fix.

## Validation

- `python -m py_compile dptb/postprocess/unified/system.py dptb/postprocess/unified/properties/band.py dptb/postprocess/unified/properties/dos.py dptb/tests/test_postprocess_unified.py`
- `uv run pytest dptb/tests/test_postprocess_unified.py -q`
- `uv run pytest dptb/tests/test_band.py -q`
