### PR TITLE
CI: add maintainer review governance safeguards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -14,11 +14,39 @@ body:
   validations:
     required: true
 
+- type: dropdown
+  attributes:
+    label: Affected area
+    description: Pick the area closest to the failure. Use Additional Context if multiple areas are involved.
+    options:
+      - Config / argcheck
+      - AtomicData / dataset
+      - OrbitalMapper / basis indexing
+      - Hamiltonian / overlap
+      - Model build / checkpoint
+      - Training / loss
+      - CLI / entrypoint
+      - Postprocess / export
+      - Documentation / examples
+      - Other
+
+- type: textarea
+  attributes:
+    label: Config, data, or checkpoint involved
+    description: |
+      Link or paste the relevant config path, dataset type/path, checkpoint path, and whether the failure depends on a specific dtype/device.
+
 - type: textarea
   attributes:
     label: Expected behavior
     description: |
       A clear and concise description of what you expected to happen.
+
+- type: textarea
+  attributes:
+    label: Expected vs actual numerical behavior
+    description: |
+      For numerical issues, describe expected values, actual values, tolerances, shapes, ordering, units, or whether the difference is systematic/random.
 
 - type: textarea
   attributes:
@@ -30,6 +58,12 @@ body:
       3. [e.g. run DeePTB with ...]
 
       It is recommended to attach your calculation case here for the developers to reproduce the bug.
+
+- type: textarea
+  attributes:
+    label: Minimal reproduction
+    description: |
+      Provide the smallest command, config, structure, or snippet that reproduces the issue. If a full dataset is required, explain why.
 
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -12,6 +12,16 @@ body:
       Example: The documentation for the band structure calculations is missing. I have read the online manual, but I am still not sure how to do it. My suggestion is to add a new section to the online manual that describes this.
   validations:
       required: true
+- type: textarea
+  attributes:
+    label: Affected command, config, or example path
+    description: |
+      Include the command, config option, example file, docs path, or notebook path related to this documentation issue.
+- type: textarea
+  attributes:
+    label: Behavior mismatch
+    description: |
+      If the docs disagree with current behavior, describe what the docs say and what DeePTB actually does.
 - type: markdown
   attributes:
     value: >

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -12,6 +12,21 @@ body:
   validations:
     required: true
 
+- type: dropdown
+  attributes:
+    label: Affected area
+    description: Pick the area that would most likely need implementation or review.
+    options:
+      - Model / Hamiltonian
+      - Data / AtomicData
+      - Config schema
+      - CLI / workflow
+      - Training / loss
+      - Postprocess / export
+      - Plugin / integration
+      - Documentation / examples
+      - Other
+
 - type: textarea
   attributes:
     label: Describe the solution you'd like
@@ -19,6 +34,18 @@ body:
       A clear and concise description of what you want to happen.
   validations:
     required: true
+
+- type: textarea
+  attributes:
+    label: Compatibility expectations
+    description: |
+      Describe whether this should preserve existing API, CLI, config, checkpoint, dataset, or output-format behavior.
+
+- type: textarea
+  attributes:
+    label: Test or example expectations
+    description: |
+      Describe the expected smoke/regression/slow tests or runnable examples that should cover this feature.
 
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/tests.yml
+++ b/.github/ISSUE_TEMPLATE/tests.yml
@@ -11,6 +11,36 @@ body:
   validations:
     required: true
 
+- type: dropdown
+  attributes:
+    label: Target pytest marker
+    description: Choose the intended test layer from docs/maintenance/test_strategy.md.
+    options:
+      - smoke
+      - regression
+      - slow
+      - unmarked / exploratory
+
+- type: dropdown
+  attributes:
+    label: Risk area
+    description: Choose the closest area from docs/maintenance/risk_map.md.
+    options:
+      - AtomicDataDict contract
+      - Orbital indexing
+      - Hamiltonian expansion
+      - Model assembly
+      - Config schema
+      - Training behavior
+      - Loss behavior
+      - Embedding and prediction
+      - Dataset backends
+      - CLI entrypoints
+      - Postprocess and export
+      - Plugins
+      - Documentation / examples
+      - Other
+
 - type: textarea
   attributes:
     label: Additional Context

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,55 @@
+## Scope
+
+Briefly describe what this PR changes and why.
+
+## DeePTB Impact Area
+
+Check every area that may be affected, even indirectly.
+
+- [ ] AtomicData / dataset loading
+- [ ] AtomicDataDict keys or tensor semantics
+- [ ] OrbitalMapper / basis-to-index mapping
+- [ ] Hamiltonian / overlap construction
+- [ ] Model build / checkpoint loading
+- [ ] NNENV / NNSK / DFTBSK / MIX behavior
+- [ ] Config schema / defaults / examples
+- [ ] Training / testing / loss behavior
+- [ ] CLI / postprocess / export
+- [ ] Documentation only
+
+## Risk And Compatibility
+
+- Risk level: low / medium / high
+- Public API changed: yes / no
+- CLI behavior changed: yes / no
+- Config schema changed: yes / no
+- Checkpoint compatibility affected: yes / no
+- Dataset format compatibility affected: yes / no
+
+If any answer is "yes", explain the intended compatibility behavior.
+
+## Tests
+
+List the tests you ran and the behavior they cover.
+
+```bash
+
+```
+
+## AI Assistance
+
+- [ ] This PR used AI assistance for code, tests, docs, or review.
+- [ ] AI-generated changes were manually checked for DeePTB domain correctness.
+- [ ] AI review findings were handled or explicitly waived below.
+
+Notes:
+
+## Merge Decision
+
+For maintainers. Fill this before merging.
+
+- Recommendation: merge / merge after fixes / hold
+- Remaining risks:
+- Known limitations:
+- Follow-up issue needed: yes / no
+

--- a/.github/workflows/pr_review_plan.yml
+++ b/.github/workflows/pr_review_plan.yml
@@ -1,0 +1,30 @@
+name: PR Review Plan
+
+on:
+  pull_request:
+
+jobs:
+  review-plan:
+    name: Generate advisory PR review plan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Compute changed files
+        run: |
+          git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" > changed-files.txt
+
+      - name: Generate review plan
+        run: |
+          python scripts/ci/pr_review_plan.py --stdin < changed-files.txt > pr-review-plan.md
+          cat pr-review-plan.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pr_review_plan_comment.yml
+++ b/.github/workflows/pr_review_plan_comment.yml
@@ -1,0 +1,88 @@
+name: PR Review Plan Comment
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review-plan-comment:
+    name: Comment advisory PR review plan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
+    steps:
+      - name: Checkout trusted base code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Get changed files
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                per_page: 100,
+              }
+            );
+            const names = files.map((file) => file.filename).join("\n");
+            require("fs").writeFileSync("changed-files.txt", names);
+
+      - name: Generate review plan
+        run: |
+          python scripts/ci/pr_review_plan.py --stdin < changed-files.txt > pr-review-plan.md
+
+      - name: Comment review plan
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const marker = "<!-- deeptb-pr-review-plan -->";
+            const plan = fs.readFileSync("pr-review-plan.md", "utf8");
+            const body = [
+              marker,
+              "This advisory review plan was generated from changed file names using trusted base-branch code.",
+              "",
+              plan,
+            ].join("\n");
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                per_page: 100,
+              }
+            );
+
+            const previous = comments.find((comment) =>
+              comment.user.type === "Bot" && comment.body.includes(marker)
+            );
+
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: previous.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            }

--- a/.github/workflows/repository_hygiene.yml
+++ b/.github/workflows/repository_hygiene.yml
@@ -1,0 +1,34 @@
+name: Repository Hygiene
+
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+      - 'docs/**'
+      - 'examples/**'
+      - 'CONTEXT.md'
+      - 'scripts/ci/**'
+  push:
+    branches: [ main ]
+    paths:
+      - '.github/**'
+      - 'docs/**'
+      - 'examples/**'
+      - 'CONTEXT.md'
+      - 'scripts/ci/**'
+
+jobs:
+  hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Check repository hygiene
+        run: python scripts/ci/check_repository_hygiene.py
+

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,57 @@
+# DeePTB Context
+
+This file records the domain language and maintenance assumptions used when reviewing DeePTB changes. It is written for maintainers, contributors, and AI-assisted review tools.
+
+## Project Shape
+
+DeePTB is a scientific machine learning package for tight-binding electronic structure simulation. Its core workflow is:
+
+```text
+AtomicData
+  -> OrbitalMapper
+  -> embedding
+  -> prediction
+  -> Hamiltonian / overlap transform
+  -> eigenvalues, matrices, or exported electronic-structure artifacts
+```
+
+Correctness depends on tensor semantics, orbital indexing, physical invariants, and backward compatibility with existing configs, checkpoints, and datasets.
+
+## Core Concepts
+
+**AtomicData** represents structures and graph data used by DeePTB models.
+
+**AtomicDataDict** is the shared dictionary interface between data, model, training, and postprocess code. Key names and tensor meanings are part of the public internal contract. Do not rename, repurpose, or silently reshape keys without tests and migration notes.
+
+**OrbitalMapper** is the authority for translating basis definitions into orbital, bond, and block indices. Code that depends on orbital ordering should go through OrbitalMapper rather than rebuilding index logic locally.
+
+**Reduced matrix elements** are direction-independent matrix elements predicted or parameterized before Hamiltonian expansion. Models should keep this representation until the Hamiltonian transform stage.
+
+**Hamiltonian transform** expands reduced matrix elements into full orbital blocks. DeePTB has SK and E3 paths; changes here are high risk because small ordering, sign, dtype, or shape changes can alter physical outputs.
+
+**Overlap** is optional but must remain consistent with the Hamiltonian path when enabled. Tests should cover overlap behavior when a change touches shared matrix construction logic.
+
+## Model Types
+
+Model type is determined from `model_options`.
+
+**NNENV** uses embedding plus prediction layers to produce Hamiltonian terms. It supports SKTB and E3TB methods.
+
+**NNSK** learns Slater-Koster parameters with analytic functional forms.
+
+**DFTBSK** uses fixed Slater-Koster parameters from a DFTB database.
+
+**MIX** combines a base SK model with neural corrections. Its multiplicative correction behavior is part of the model contract.
+
+## Review Priorities
+
+When reviewing a PR, focus first on:
+
+- AtomicDataDict key meaning and tensor shape changes.
+- OrbitalMapper ordering and basis mapping changes.
+- Reduced matrix element conventions.
+- SK/E3 Hamiltonian expansion behavior.
+- Config schema, defaults, docs, and examples staying aligned.
+- Checkpoint and dataset backward compatibility.
+- Tests that cover changed scientific behavior, not just import success.
+

--- a/docs/AI_CODING_GUIDE.md
+++ b/docs/AI_CODING_GUIDE.md
@@ -1,0 +1,44 @@
+# AI Coding Guide
+
+This guide defines how AI-assisted coding should be used in DeePTB. AI can help draft code, tests, docs, and reviews, but maintainers remain responsible for scientific correctness.
+
+## Required Discipline
+
+- Treat tensor shape, dtype, device, batching, and key semantics as correctness issues.
+- Prefer existing DeePTB interfaces and domain concepts over new helper layers.
+- Keep changes scoped to the PR goal. Avoid drive-by cleanup in high-risk modules.
+- Update tests, examples, and docs when config, CLI, data format, or public behavior changes.
+- Mark AI-assisted PRs in the PR template.
+
+## Red Lines
+
+AI-generated changes must not silently:
+
+- Rename or repurpose `AtomicDataDict` keys.
+- Change orbital ordering or basis mapping outside `OrbitalMapper`.
+- Change reduced matrix element conventions.
+- Change SK or E3 Hamiltonian block expansion semantics.
+- Change config defaults or schema without docs and tests.
+- Change checkpoint or dataset compatibility without an explicit migration path.
+- Move domain logic into generic utilities where reviewers cannot see the physics meaning.
+
+## High-Risk Changes Need Regression Tests
+
+Add or update regression tests when touching:
+
+- `dptb/data/_keys.py`
+- `dptb/data/transforms.py`
+- `dptb/nn/hamiltonian.py`
+- `dptb/nn/build.py`
+- `dptb/utils/argcheck.py`
+- `dptb/nnops/loss.py`
+- `dptb/nnops/trainer.py`
+
+Useful regression tests usually check concrete behavior: tensor keys, shapes, ordering, config parsing, checkpoint loading, numerical outputs, or CLI behavior.
+
+## Review Prompts For AI Tools
+
+Use the prompts in `docs/maintenance/ai_review_prompts.md` for repeatable review. The recommended minimum set is:
+
+- Maintainer Review: correctness, compatibility, risk, and merge recommendation.
+- Test Gap Review: changed behavior that is missing regression, smoke, or example coverage.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -12,6 +12,7 @@ We heartily welcome contributions to the DeePTB project. This guide provides tec
 - [Adding a Unit Test](#adding-a-unit-test)
 - [Running Unit Tests](#running-unit-tests)
 - [Submitting a Pull Request](#submitting-a-pull-request)
+- [Maintainer Review Expectations](#maintainer-review-expectations)
 - [After Your Pull Request is Merged](#after-your-pull-request-is-merged)
 - [Commit Message Guidelines](#commit-message-guidelines)
 
@@ -80,6 +81,19 @@ pytest ./dptb/tests/test_file.py
 5. Push your branch to your fork on GitHub.
 6. Submit a pull request (PR) with `deepmodeling/DeePTB:main` as the base repository. It is required to document your PR following [our guidelines](#commit-message-guidelines).
 
+## Maintainer Review Expectations
+
+DeePTB is a scientific machine learning codebase where small changes to tensor semantics, orbital indexing, config defaults, or Hamiltonian construction can affect many downstream workflows. Pull requests should make their impact and remaining risk explicit.
+
+- Use the PR template to describe the scope, affected DeePTB areas, compatibility impact, tests, and merge decision.
+- If AI assistance was used, mark it in the PR template and manually check the DeePTB domain assumptions.
+- Review `../CONTEXT.md` for core DeePTB concepts before changing data, model, Hamiltonian, training, or export behavior.
+- Review `maintenance/risk_map.md` before changing high-risk modules.
+- Follow `AI_CODING_GUIDE.md` when using AI tools for implementation or review.
+- Run `python scripts/ci/check_repository_hygiene.py` when changing examples, config files, maintenance docs, or docs navigation.
+- Run the relevant pytest marker subset from `maintenance/test_strategy.md` for the area you changed.
+- Maintainers should use `maintenance/maintainer_sop.md` and `maintenance/review_workflow.md` to record remaining risks before merging.
+
 ### After Your Pull Request is Merged
 
 - Delete the remote branch on GitHub either [through the GitHub web UI](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/deleting-and-restoring-branches-in-a-pull-request#deleting-a-branch-used-for-a-pull-request) or your local shell as follows:
@@ -145,4 +159,3 @@ Fixes #123
   - description: A short summary of the code changes: tell others what you did in one sentence.
 - Body: optional, providing detailed, additional, or contextual information about the code changes, e.g. the motivation of this commit, referenced materials, the coding implementation, and so on.
 - Footer: optional, reference GitHub issues or PRs that this commit closes or is related to. [Use a keyword](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to close an issue, e.g. "Fix #753".
-

--- a/docs/adr/0001-reduced-matrix-elements.md
+++ b/docs/adr/0001-reduced-matrix-elements.md
@@ -1,0 +1,25 @@
+# ADR 0001: Keep Reduced Matrix Elements Until Hamiltonian Transform
+
+## Status
+
+Accepted
+
+## Context
+
+DeePTB models predict or parameterize reduced, direction-independent matrix elements before constructing full orbital-block Hamiltonian or overlap matrices. Both SK and E3 paths rely on this separation.
+
+This design keeps model prediction separate from direction-dependent matrix expansion, which is important for clarity, equivariance, and reuse across model types.
+
+## Decision
+
+DeePTB should keep reduced matrix elements as the model-side representation and expand them to full Hamiltonian or overlap blocks at the Hamiltonian transform stage.
+
+Changes that move direction-dependent expansion earlier in the pipeline should be treated as architecture changes and require explicit tests and review.
+
+## Consequences
+
+- Model code can focus on predicting reduced terms.
+- Hamiltonian transform code remains the authority for full block construction.
+- Tests should verify both reduced element conventions and expanded block behavior when this path changes.
+- AI-assisted refactors must not hide expansion semantics in generic helpers.
+

--- a/docs/adr/0002-orbitalmapper-as-index-authority.md
+++ b/docs/adr/0002-orbitalmapper-as-index-authority.md
@@ -1,0 +1,23 @@
+# ADR 0002: Use OrbitalMapper As The Index Authority
+
+## Status
+
+Accepted
+
+## Context
+
+Basis definitions, orbital ordering, bond types, and block indices appear across data processing, model construction, Hamiltonian assembly, training, and postprocess code. Duplicating index logic makes it easy for two paths to disagree while still passing superficial shape checks.
+
+## Decision
+
+`OrbitalMapper` is the authority for basis-to-index and orbital-block mapping in DeePTB. Callers should use it rather than reconstructing orbital ordering or block index rules locally.
+
+Any change to `OrbitalMapper` behavior should be reviewed as a compatibility-sensitive change.
+
+## Consequences
+
+- Index mapping behavior has locality in one module.
+- Mixed-basis and multi-species behavior should be regression-tested through `OrbitalMapper`.
+- Downstream modules should not infer orbital ordering from ad hoc string or list manipulation.
+- AI-assisted code should be rejected if it duplicates index mapping logic outside the established mapper path.
+

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,11 @@
+# Architecture Decision Records
+
+Architecture Decision Records explain decisions that future reviews should not rediscover from scratch.
+
+```{toctree}
+:maxdepth: 1
+
+0001-reduced-matrix-elements
+0002-orbitalmapper-as-index-authority
+```
+

--- a/docs/advanced/elec_properties/index.rst
+++ b/docs/advanced/elec_properties/index.rst
@@ -4,3 +4,5 @@ Electronic Properties and Outputs
 
 .. toctree::
    band
+   dos
+   fermi_surface

--- a/docs/advanced/sktb/dptb_env.md
+++ b/docs/advanced/sktb/dptb_env.md
@@ -148,7 +148,7 @@ and that is controlled by parameters in `nnsk` keyword in the `model_options` se
 - `rs` (angstrom unit): $r_{skc}$ it controls the cutoff of the decay weight of each bond.
 - `w`: $\omega$, it decides the smoothness of the decay.
 
-![fs](../img/fs.png)
+![fs](../../img/fs.png)
 
 As is shown in the above figure, this smoothing function will decay centred at $r_{skc}$. According to the smoothness $\omega$, this function has different smoothness. Here, to take more neighbours' terms into consideration while retaining the stability of fitting, we first set the $r_{skc}$ at the first-nearest neighbour distance, this decay function can suppress the newly included second and third neighbour terms, which brings no abrupt changes to the predicted hamiltonians.
 
@@ -219,4 +219,3 @@ We can use the converged model to predict the bandstructure, calculating propert
 <img src="https://raw.githubusercontent.com/deepmodeling/DeePTB/main/docs/img/silicon_band_dptb.png" alt="band_dptb" width="500"/>
 
 Now you know how to train a **DeePTB** model, congratulations!
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,5 +76,11 @@ For more details, see our papers:
    :caption: Community
 
    community/contribution_guide
+   community/faq
    CONTRIBUTING
 
+.. toctree::
+   :maxdepth: 2
+   :caption: Maintenance
+
+   maintenance/index

--- a/docs/maintenance/ai_review_prompts.md
+++ b/docs/maintenance/ai_review_prompts.md
@@ -1,0 +1,98 @@
+# AI Review Prompts
+
+These prompts make AI-assisted PR review repeatable. They are advisory and do not replace maintainer judgment, especially for physics semantics, numerical behavior, and compatibility decisions.
+
+## How To Use
+
+Prepare this context before running either prompt:
+
+- PR title and body.
+- PR diff against `main`.
+- `CONTEXT.md`.
+- `docs/maintenance/risk_map.md`.
+- `docs/maintenance/test_strategy.md`.
+- Any relevant CI output or local test output.
+
+Run both prompts independently. Put the useful results in the PR's AI Assistance notes, maintainer review notes, or Merge Decision section. If a finding is intentionally waived, record why.
+
+## Maintainer Review Prompt
+
+```text
+You are reviewing a DeePTB pull request as a maintainer.
+
+Use the provided PR title, PR body, diff, CONTEXT.md, risk_map.md, test_strategy.md, and CI/test output.
+
+Focus on:
+- scientific correctness and regressions against main;
+- AtomicDataDict key semantics;
+- OrbitalMapper basis/index mapping;
+- reduced matrix element conventions;
+- SK/E3 Hamiltonian and overlap transforms;
+- model type detection for NNENV/NNSK/DFTBSK/MIX;
+- config schema, checkpoint, dataset, CLI, docs, and example compatibility;
+- tensor shape, dtype, device, batching, ordering, and masking behavior;
+- whether high-risk files from risk_map.md were touched.
+
+Do not comment on style unless it affects correctness, maintainability, or behavior.
+Do not invent test results. If evidence is missing, say what should be verified.
+
+Return Markdown with exactly these sections:
+
+## Summary
+Briefly describe what changed.
+
+## Risk Level
+Low, Medium, or High. Explain the main reason.
+
+## Blockers
+Issues that should prevent merge. Use "None found" if there are none.
+
+## Non-Blocking Risks
+Risks that can be accepted, deferred, or watched.
+
+## Human Review Focus
+Specific files, functions, tensor contracts, or compatibility points a maintainer should inspect.
+
+## Suggested Tests
+Concrete tests to run or add. Mention relevant pytest markers from test_strategy.md.
+
+## Merge Recommendation
+One of: merge, merge after fixes, hold. Explain briefly.
+```
+
+## Test Gap Review Prompt
+
+```text
+You are reviewing only the test coverage of a DeePTB pull request.
+
+Use the provided PR title, PR body, diff, CONTEXT.md, risk_map.md, test_strategy.md, and CI/test output.
+
+Focus only on changed behavior that may be insufficiently tested:
+- AtomicDataDict keys, tensor shapes, dtype, device, batch behavior, and ordering;
+- OrbitalMapper basis/index mapping;
+- reduced matrix elements and Hamiltonian/overlap expansion;
+- model build/type detection and checkpoint loading;
+- config schema/defaults and docs/examples consistency;
+- CLI, export, postprocess, and training workflows;
+- compatibility with existing datasets, configs, and checkpoints.
+
+Do not review style. Do not repeat general testing advice. Do not invent tests that already ran unless the evidence is absent.
+
+Return Markdown with exactly these sections:
+
+## Coverage Summary
+State which changed behaviors appear covered and which do not.
+
+## Missing Or Weak Tests
+List concrete gaps. Use "None found" if there are none.
+
+## Recommended Pytest Markers
+Name which marker subsets should be run: smoke, regression, not slow, slow, or full suite.
+
+## Regression Tests To Add
+List specific regression tests that should be added or updated.
+
+## Example Or CLI Smoke Coverage
+Mention example config, CLI, or docs smoke checks needed for user-facing changes.
+```
+

--- a/docs/maintenance/docs_warning_triage.md
+++ b/docs/maintenance/docs_warning_triage.md
@@ -1,0 +1,53 @@
+# Docs Warning Triage
+
+This page tracks known Sphinx warning classes so documentation review can focus on meaningful regressions instead of rediscovering existing noise.
+
+## Local Check
+
+```bash
+uv run python -m sphinx -b html docs /private/tmp/deeptb-docs-check
+```
+
+## Warning Classes
+
+| Warning class | Current policy |
+| --- | --- |
+| Missing toctree entries | Fix low-risk documentation pages when they are already part of the public docs. Keep design notes unlisted unless they are ready for public navigation. |
+| Image path warnings | Fix direct path mistakes. Prefer paths that resolve from the Markdown file location. |
+| Markdown heading warnings | Fix obvious cases where a Markdown document starts at `##` instead of `#`. |
+| Code block highlighting warnings | Track only for now. Many examples contain JSON-like snippets with comments or ellipses; fixing them requires broader historical docs cleanup. |
+| Notebook execution or output warnings | Track only for now. Do not change notebook contents or execution policy in maintenance-only PRs. |
+| Third-party Sphinx deprecation warnings | Track only for now unless they break the build. |
+
+## Fixed In This Maintenance Pass
+
+- Added low-risk public pages to toctrees for electronic properties, community docs, and quick examples.
+- Fixed the smoothing-function image path in `docs/advanced/sktb/dptb_env.md`.
+- Converted `docs/pardiso_architecture.md` to start with a real H1 Markdown heading.
+
+## Last Observed Full Build
+
+Command:
+
+```bash
+uv run python -m sphinx -b html docs /private/tmp/deeptb-docs-check
+```
+
+Latest maintenance validation succeeded with 41 warnings. The warnings are still in the tracked classes above:
+
+- missing `_static` directory from `html_static_path`;
+- notebook execution failures for quick-start notebooks, with tracebacks written under the build `reports/` directory;
+- unlisted design/status notes: `docs/pardiso_architecture.md` and `docs/phase1_summary.md`;
+- definition-list formatting in `docs/input_params/run_options.rst`;
+- historical code block highlighting warnings from JSON-like snippets with comments, ellipses, tree glyphs, traceback text, or non-ASCII math symbols;
+- missing MyST cross references in `docs/phase1_summary.md` and `docs/quick_start/hands_on/tutorial4_E3_si.ipynb`;
+- `deepmodeling_sphinx` deprecation warnings for Sphinx 9 APIs.
+
+This maintenance pass does not attempt to execute or repair notebooks, rewrite historical code snippets, or promote design/status notes into public navigation.
+
+## Known Warnings Left For Later
+
+- Code block highlighting warnings in historical docs that use JSON-like examples with comments or ellipses.
+- Notebook execution or notebook output warnings.
+- Unlisted design/status notes such as `docs/phase1_summary.md`.
+- Sphinx/deepmodeling_sphinx deprecation or static-copy warnings that do not fail the build.

--- a/docs/maintenance/index.md
+++ b/docs/maintenance/index.md
@@ -1,0 +1,17 @@
+# Maintenance
+
+These documents define DeePTB's review and maintenance workflow.
+
+```{toctree}
+:maxdepth: 1
+
+../AI_CODING_GUIDE
+ai_review_prompts
+docs_warning_triage
+maintainer_sop
+pr_review_plan
+review_workflow
+risk_map
+test_strategy
+../adr/index
+```

--- a/docs/maintenance/maintainer_sop.md
+++ b/docs/maintenance/maintainer_sop.md
@@ -1,0 +1,112 @@
+# Maintainer PR Review SOP
+
+This SOP turns DeePTB's maintenance documents into a concrete PR review flow. It is meant for maintainers reviewing alone or with AI assistance.
+
+## 1. Intake
+
+Start by reading the PR title, body, changed files, and CI status.
+
+- Confirm the scope is clear and not mixed with unrelated cleanup.
+- Check the DeePTB Impact Area section in the PR template.
+- Check whether AI assistance was used and whether the author documented manual review.
+- Check compatibility answers for public API, CLI, config schema, checkpoints, and datasets.
+- Ask for clarification before reviewing deeply if the PR intent is unclear.
+
+## 2. Risk Triage
+
+Use `docs/maintenance/risk_map.md` to classify the PR.
+For a first-pass advisory plan, run:
+
+```bash
+git diff --name-only main...HEAD | python scripts/ci/pr_review_plan.py --stdin
+```
+
+Use the script output as a prompt for human review, not as an automatic merge decision.
+On GitHub, the advisory PR Review Plan may also appear as a bot comment. That comment is generated from changed file names only; it should start the review, not end it.
+
+**Low risk**
+
+- Documentation-only changes.
+- Issue template or maintenance text changes.
+- Packaging metadata changes without dependency or install behavior changes.
+
+**Medium risk**
+
+- Embedding, prediction, dataset backend, CLI, postprocess, export, or plugin changes.
+- Docs/examples changes that affect user commands or config snippets.
+
+**High risk**
+
+- Any high-risk file from `risk_map.md`.
+- Changes to tensor shapes, dtype, device movement, batching, ordering, masks, or key names.
+- Changes to config schema/defaults, checkpoint compatibility, dataset compatibility, Hamiltonian/overlap, eigenvalues, loss, training behavior, or export semantics.
+- PRs that touch both data representation and model behavior.
+
+If the PR risk level in the template disagrees with this triage, use the higher risk level unless the reason is clearly documented.
+
+## 3. AI Review
+
+For medium and high risk PRs, run both prompts from `docs/maintenance/ai_review_prompts.md`:
+
+- Maintainer Review Prompt.
+- Test Gap Review Prompt.
+
+Use the PR title, PR body, diff against `main`, `CONTEXT.md`, `risk_map.md`, `test_strategy.md`, and relevant CI or local test output as context.
+
+AI findings are advisory. Handle each actionable finding by fixing it, asking the author to fix it, or recording why it is waived.
+
+## 4. Test Selection
+
+Choose the smallest test set that matches the PR risk, then expand when evidence is missing.
+
+```bash
+python scripts/ci/check_repository_hygiene.py
+uv run pytest ./dptb/tests -m smoke
+uv run pytest ./dptb/tests -m regression
+uv run pytest ./dptb/tests -m "not slow"
+uv run pytest ./dptb/tests
+```
+
+- Run repository hygiene for examples, docs navigation, maintenance docs, or workflow changes.
+- Run `smoke` for broad PRs before deep review.
+- Run `regression` for high-risk files or compatibility-sensitive behavior.
+- Run `not slow` when you need wider confidence without the heaviest workflows.
+- Run the full suite before merging changes to model behavior, training, Hamiltonian construction, datasets, checkpoint behavior, or public workflows.
+
+Do not treat missing local optional dependencies as silent success. Record the skipped environment and whether CI covers it.
+
+## 5. Hold Conditions
+
+Hold the PR instead of merging when any of these apply:
+
+- PR scope is unclear or mixes unrelated changes.
+- High-risk behavior changed without a regression test or a documented waiver.
+- Config, checkpoint, dataset, CLI, or public API compatibility is unclear.
+- CI failed and the failure is not explained.
+- AI review identified a plausible correctness issue that was not resolved or waived.
+- Tensor/key/order semantics changed but the PR does not explain the intended behavior.
+- Remaining risk is too large to describe in the Merge Decision.
+
+## 6. Merge Decision
+
+Before merging, fill the PR template's Merge Decision section.
+
+```md
+Recommendation: merge / merge after fixes / hold
+
+Reason:
+- ...
+
+Tests:
+- ...
+
+Remaining risks:
+- ...
+
+Known limitations:
+- ...
+
+Follow-up issue needed: yes / no
+```
+
+The merge decision should make future debugging easier. If a risk is accepted, name it directly.

--- a/docs/maintenance/pr_review_plan.md
+++ b/docs/maintenance/pr_review_plan.md
@@ -1,0 +1,66 @@
+# PR Review Plan
+
+`scripts/ci/pr_review_plan.py` turns changed files into an advisory review plan. It is the active counterpart to the maintainer SOP: instead of expecting the maintainer to remember every rule, it prints the likely risk level, review focus, AI prompt suggestions, tests, and hold conditions.
+
+The script is stdlib-only and does not call GitHub, AI services, or DeePTB runtime dependencies.
+
+## Local Usage
+
+Pass files directly:
+
+```bash
+python scripts/ci/pr_review_plan.py --changed-files dptb/nn/hamiltonian.py
+```
+
+Or pipe changed files from git:
+
+```bash
+git diff --name-only main...HEAD | python scripts/ci/pr_review_plan.py --stdin
+```
+
+The output is Markdown and can be pasted into a PR's AI Assistance or Merge Decision notes.
+
+## GitHub Automation
+
+DeePTB has two advisory workflows for this plan:
+
+- `.github/workflows/pr_review_plan.yml` runs on `pull_request` and writes the plan to the Actions job summary.
+- `.github/workflows/pr_review_plan_comment.yml` runs on `pull_request_target` and writes or updates one PR comment.
+
+The comment workflow is designed for fork PRs. It checks out the trusted base commit from the main repository, reads changed file names through the GitHub API, then runs the base-branch copy of `scripts/ci/pr_review_plan.py`. It must not checkout or execute code from the fork branch.
+
+Required permissions for the comment workflow are intentionally narrow:
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+```
+
+`issues: write` is needed because PR timeline comments use the issues comments API. The workflow updates the existing bot comment using a hidden marker instead of creating a new comment on every PR update.
+
+## How To Read The Output
+
+- **Risk level** follows `docs/maintenance/risk_map.md`.
+- **Touched risk areas** show which mapped areas were changed.
+- **Required maintainer focus** lists what a human should inspect.
+- **Suggested AI review** points to the minimum recommended prompts.
+- **Suggested checks** lists likely local commands for this PR.
+- **Hold conditions** names situations that should stop merge until resolved or explicitly waived.
+
+The plan is advisory. When the PR body, maintainer judgment, or scientific impact suggests higher risk than the file map, use the higher risk level.
+
+## Examples
+
+Hamiltonian changes should be treated as high risk:
+
+```bash
+printf "dptb/nn/hamiltonian.py\n" | python scripts/ci/pr_review_plan.py --stdin
+```
+
+Docs-only changes should normally stay low risk:
+
+```bash
+printf "docs/index.rst\n" | python scripts/ci/pr_review_plan.py --stdin
+```

--- a/docs/maintenance/review_workflow.md
+++ b/docs/maintenance/review_workflow.md
@@ -1,0 +1,95 @@
+# Review Workflow
+
+DeePTB has more code paths than the current maintainer capacity can review manually from scratch every time. The review workflow should make AI useful, CI mechanically strict, and human review focused on design and scientific risk.
+
+## PR Review Pipeline
+
+Use three layers:
+
+1. **AI-assisted review** identifies likely risks, missing tests, and compatibility concerns.
+2. **CI** catches mechanical failures, regressions, and smoke-test breakage.
+3. **Human maintainer review** decides whether the remaining risk is acceptable.
+
+AI review is advisory. It should not replace maintainer judgment, especially for physics semantics and numerical behavior.
+
+For the step-by-step PR procedure, use `docs/maintenance/maintainer_sop.md`.
+
+## Minimal AI Review Roles
+
+Before running prompts, generate a file-based review plan when reviewing a local branch:
+
+```bash
+git diff --name-only main...HEAD | python scripts/ci/pr_review_plan.py --stdin
+```
+
+The same script can run in GitHub Actions as an advisory job summary. Treat it as a checklist generator, not as an automated approval.
+
+Start with two roles before adding more automation. Use the prompt text in `docs/maintenance/ai_review_prompts.md` so manual review and future automation follow the same rules.
+
+**Maintainer Review**
+
+- correctness bugs
+- regressions against main
+- public API, config, checkpoint, and dataset compatibility
+- high-risk modules touched
+- merge recommendation
+
+**Test Gap Review**
+
+- changed behavior without tests
+- examples or CLI paths that should be smoke-tested
+- regression tests needed for scientific behavior
+
+These two prompts are the recommended minimum AI review set. Future CodeRabbit, OpenClaw, Hermes, or GitHub Action automation should reuse them rather than creating a separate review standard.
+
+## Maintainer Checklist
+
+- [ ] PR scope is clear and not mixed with unrelated cleanup.
+- [ ] High-risk files were reviewed using `docs/maintenance/risk_map.md`.
+- [ ] Main branch behavior is preserved unless explicitly changed.
+- [ ] Public API, CLI, docs, examples, and config schema are consistent.
+- [ ] Tests cover the changed behavior.
+- [ ] AI review findings were handled or explicitly waived.
+- [ ] CI passed.
+- [ ] Remaining risks are recorded in the PR merge decision.
+
+## Repository Hygiene Check
+
+The repository hygiene check is a low-noise CI guard for hard errors only. It verifies that example JSON files parse, required maintenance documents exist, and the maintenance docs remain linked from the docs index.
+
+Run it locally with:
+
+```bash
+python scripts/ci/check_repository_hygiene.py
+```
+
+This check does not replace full unit tests, Sphinx docs builds, notebook validation, or human review.
+
+## Test Layering
+
+Use pytest markers to match test effort to PR risk:
+
+```bash
+uv run pytest ./dptb/tests -m smoke
+uv run pytest ./dptb/tests -m regression
+uv run pytest ./dptb/tests -m "not slow"
+uv run pytest ./dptb/tests
+```
+
+See `docs/maintenance/test_strategy.md` for marker definitions and review guidance.
+
+## Merge Decision Template
+
+Use the PR template's Merge Decision section before merging:
+
+```md
+Recommendation: merge after CI passes.
+
+Reason:
+- Core workflow is covered by regression tests.
+- AI review concerns were resolved.
+- No unresolved compatibility issues.
+
+Remaining risks:
+- Real MKL/Pardiso path requires Linux + MKL environment and is not covered in this PR.
+```

--- a/docs/maintenance/risk_map.md
+++ b/docs/maintenance/risk_map.md
@@ -1,0 +1,51 @@
+# Risk Map
+
+This map helps maintainers decide how much review and testing a PR needs. It is intentionally practical: files are high risk when a small change can alter scientific results, compatibility, or many downstream workflows.
+
+## High Risk
+
+Changes here should normally include regression tests and maintainer review.
+
+| Area | Files | Review focus |
+| --- | --- | --- |
+| AtomicDataDict contract | `dptb/data/_keys.py` | key names, key meaning, tensor shape, downstream callers |
+| Orbital indexing | `dptb/data/transforms.py` | basis ordering, orbital block indices, mixed-basis behavior |
+| Hamiltonian expansion | `dptb/nn/hamiltonian.py` | SK/E3 transforms, signs, ordering, dtype/device, overlap |
+| Model assembly | `dptb/nn/build.py` | model type detection, checkpoint loading, config interpretation |
+| Config schema | `dptb/utils/argcheck.py` | defaults, backward compatibility, docs/examples alignment |
+| Training behavior | `dptb/nnops/trainer.py` | task detection, validation behavior, reference datasets |
+| Loss behavior | `dptb/nnops/loss.py` | numerical targets, masks, reductions, task-specific semantics |
+
+## Medium Risk
+
+Changes here may need focused tests depending on scope.
+
+| Area | Files | Review focus |
+| --- | --- | --- |
+| Embedding and prediction | `dptb/nn/embedding/`, `dptb/nn/prediction/` | tensor shape, irreps, batch behavior, model compatibility |
+| Dataset backends | `dptb/data/` except high-risk files | format compatibility, missing fields, cutoff behavior |
+| CLI entrypoints | `dptb/entrypoints/` | args, defaults, config loading, user-facing behavior |
+| Postprocess and export | `dptb/postprocess/` | exported formats, unit conventions, compatibility |
+| Plugins | `dptb/plugins/` | checkpointing, logging, training lifecycle |
+
+## Lower Risk
+
+These changes still need review, but usually do not require broad regression testing.
+
+| Area | Files | Review focus |
+| --- | --- | --- |
+| Documentation | `docs/`, `README.md`, examples README files | stale commands, stale paths, config consistency |
+| Issue templates | `.github/ISSUE_TEMPLATE/` | clarity and triage usefulness |
+| Packaging metadata | `pyproject.toml`, release docs | dependency compatibility, install behavior |
+
+## Escalation Rules
+
+Treat a PR as high risk if it:
+
+- changes a high-risk file;
+- changes public CLI/config behavior;
+- changes tensor shapes, dtype, device movement, batching, or key names;
+- changes checkpoint or dataset compatibility;
+- changes numerical behavior in Hamiltonian, overlap, eigenvalue, loss, or export paths;
+- touches both data representation and model behavior in the same PR.
+

--- a/docs/maintenance/test_strategy.md
+++ b/docs/maintenance/test_strategy.md
@@ -1,0 +1,30 @@
+# Test Strategy
+
+DeePTB tests are grouped by review purpose. The markers help maintainers pick a useful test subset for a PR without changing the existing full test workflow.
+
+## Markers
+
+**smoke** tests are quick checks for imports, config generation, model build, and core mapping entrypoints. They should be stable and low-dependency.
+
+**regression** tests protect known behavior, numerical semantics, tensor shape/order, and compatibility. High-risk changes should usually add or update a regression test.
+
+**slow** tests cover training, complex postprocess, external or optional dependency paths, and workflows that are noticeably longer-running.
+
+## Local Commands
+
+```bash
+uv run pytest ./dptb/tests -m smoke
+uv run pytest ./dptb/tests -m regression
+uv run pytest ./dptb/tests -m "not slow"
+uv run pytest ./dptb/tests
+```
+
+## Review Guidance
+
+- Run `smoke` for quick confidence before reviewing a broad PR.
+- Run `regression` when a PR touches high-risk files from `docs/maintenance/risk_map.md`.
+- Run `not slow` when you want a wider local check without the heaviest workflows.
+- Run the full test suite before merging changes that affect model behavior, training, Hamiltonian construction, datasets, or public workflows.
+
+The first version of this strategy does not make markers a required CI gate. The existing full CI workflow remains unchanged.
+

--- a/docs/pardiso_architecture.md
+++ b/docs/pardiso_architecture.md
@@ -1,4 +1,5 @@
-"""
+# Pardiso Architecture
+
 Proposed architecture for Pardiso integration.
 
 This document outlines a better design for integrating high-performance
@@ -209,4 +210,3 @@ dptb.set_backend('pardiso')
 tbsys = TBSystem(data, calculator)
 bands = tbsys.band.compute(kpath)  # Automatically fast!
 ```
-"""

--- a/docs/quick_start/hands_on/index.rst
+++ b/docs/quick_start/hands_on/index.rst
@@ -8,3 +8,5 @@ Quick Examples
    tutorial3_train_si
    tutorial4_E3_si
    tutorial5_TBPlaS
+   sktb_hands_on
+   e3tb_hands_on

--- a/dptb/tests/test_SKHamiltonian.py
+++ b/dptb/tests/test_SKHamiltonian.py
@@ -12,6 +12,8 @@ from dptb.utils.constants import anglrMId, orbitalId
 from e3nn.o3 import wigner_3j, Irrep, xyz_to_angles, Irrep
 from dptb.tests.tstools import compare_tensors_as_sets_float
 
+pytestmark = pytest.mark.regression
+
 rootdir = os.path.join(Path(os.path.abspath(__file__)).parent, "data")
 
 class TestSKHamiltonian:
@@ -260,5 +262,4 @@ class TestSKHamiltonian:
          -3.7709136009e+00]])
         
         assert torch.allclose(data[AtomicDataDict.NODE_FEATURES_KEY], expected_strainonsite, atol=1e-6, rtol=1e-4)
-
 

--- a/dptb/tests/test_build_model.py
+++ b/dptb/tests/test_build_model.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from dptb.data.transforms import OrbitalMapper
 
 
+pytestmark = pytest.mark.smoke
+
 rootdir = os.path.join(Path(os.path.abspath(__file__)).parent, "data/out")
 
 

--- a/dptb/tests/test_genconfig.py
+++ b/dptb/tests/test_genconfig.py
@@ -7,6 +7,8 @@ from dptb.utils.config_e3 import TrainFullConfigE3, TestFullConfigE3
 
 from dptb.entrypoints.config import config, get_full_config
 
+pytestmark = pytest.mark.smoke
+
 @pytest.fixture(scope='session', autouse=True)
 def root_directory(request):
     return str(request.config.rootdir)

--- a/dptb/tests/test_hr2hk.py
+++ b/dptb/tests/test_hr2hk.py
@@ -12,6 +12,8 @@ from dptb.data import AtomicDataDict
 from ase.io import read
 
 
+pytestmark = pytest.mark.regression
+
 @pytest.fixture(scope='session', autouse=True)
 def root_directory(request):
     """Get the root directory of the project."""

--- a/dptb/tests/test_nrl.py
+++ b/dptb/tests/test_nrl.py
@@ -16,6 +16,8 @@ from dptb.entrypoints.pth2json import pth2json
 from dptb.utils.tools import flatten_dict
 
 
+pytestmark = pytest.mark.slow
+
 rootdir = os.path.join(Path(os.path.abspath(__file__)).parent, "data")
 
 

--- a/dptb/tests/test_orbitalmapper.py
+++ b/dptb/tests/test_orbitalmapper.py
@@ -5,6 +5,8 @@ from collections import OrderedDict
 from dptb.data.transforms import OrbitalMapper
 from e3nn.o3._irreps import Irreps
 
+pytestmark = pytest.mark.smoke
+
 def test_orbital_mapper_init_str_spdf():
     # 创建一个OrbitalMapper实例
     basis = {"A": "2s2p3d1f", "B": "1s2f3d1f"}
@@ -493,4 +495,3 @@ def test_equality_operator():
     basis = {"C": ['2s','2p','d*'], "O": ['2s','2p','f*']}
     orbmap2 = OrbitalMapper(basis=basis, method="sktb", device=torch.device("cpu"))
     assert orbmap != orbmap2
-

--- a/dptb/tests/test_postprocess_unified.py
+++ b/dptb/tests/test_postprocess_unified.py
@@ -10,6 +10,8 @@ from dptb.postprocess.unified.properties.dos import DosData
 from dptb.postprocess.unified.utils import calculate_fermi_level
 from dptb.data import AtomicDataDict
 
+pytestmark = pytest.mark.regression
+
 # Paths to example data
 # Using relative paths from the project root (where tests are usually run from)
 # or absolute paths if needed.

--- a/dptb/tests/test_sktb.py
+++ b/dptb/tests/test_sktb.py
@@ -6,6 +6,8 @@ import numpy as np
 from dptb.utils.tools import j_loader
 import json
 
+pytestmark = pytest.mark.slow
+
 @pytest.fixture(scope='session', autouse=True)
 def root_directory(request):
     return str(request.config.rootdir)

--- a/dptb/tests/test_soc.py
+++ b/dptb/tests/test_soc.py
@@ -16,6 +16,8 @@ from dptb.entrypoints.pth2json import pth2json
 from dptb.utils.tools import flatten_dict
 
 
+pytestmark = pytest.mark.slow
+
 rootdir = os.path.join(Path(os.path.abspath(__file__)).parent, "data")
 
 

--- a/dptb/tests/test_trainer.py
+++ b/dptb/tests/test_trainer.py
@@ -7,6 +7,8 @@ from dptb.utils.tools import j_loader
 from dptb.nn.build import build_model
 from dptb.data.build import build_dataset
 
+pytestmark = pytest.mark.slow
+
 rootdir = os.path.join(Path(os.path.abspath(__file__)).parent, "data")
 
 class TestTrainer:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,3 +86,10 @@ dev = [
     "jupyter",
     "notebook",
 ]
+
+[tool.pytest.ini_options]
+markers = [
+    "smoke: quick checks for imports, config generation, model build, and core mapping entrypoints",
+    "regression: behavior-preserving tests for numerical semantics, tensor shape/order, and compatibility",
+    "slow: training, complex postprocess, external/optional dependency, or otherwise long-running tests",
+]

--- a/scripts/ci/check_repository_hygiene.py
+++ b/scripts/ci/check_repository_hygiene.py
@@ -74,7 +74,11 @@ def check_docs_index() -> list[str]:
     if not index_path.is_file():
         return ["docs/index.rst: required docs index is missing"]
 
-    content = index_path.read_text(encoding="utf-8")
+    try:
+        content = index_path.read_text(encoding="utf-8")
+    except Exception as exc:  # noqa: BLE001 - report any read failure.
+        return [f"docs/index.rst: unreadable ({type(exc).__name__}: {exc})"]
+
     for entry in REQUIRED_DOCS_INDEX_ENTRIES:
         if entry not in content:
             errors.append(f"docs/index.rst: missing toctree entry '{entry}'")
@@ -90,7 +94,11 @@ def check_maintenance_index() -> list[str]:
     if not index_path.is_file():
         return ["docs/maintenance/index.md: required maintenance index is missing"]
 
-    content = index_path.read_text(encoding="utf-8")
+    try:
+        content = index_path.read_text(encoding="utf-8")
+    except Exception as exc:  # noqa: BLE001 - report any read failure.
+        return [f"docs/maintenance/index.md: unreadable ({type(exc).__name__}: {exc})"]
+
     for entry in REQUIRED_MAINTENANCE_INDEX_ENTRIES:
         if entry not in content:
             errors.append(f"docs/maintenance/index.md: missing toctree entry '{entry}'")

--- a/scripts/ci/check_repository_hygiene.py
+++ b/scripts/ci/check_repository_hygiene.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Low-noise repository hygiene checks for DeePTB."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+REQUIRED_FILES = (
+    ".github/workflows/pr_review_plan.yml",
+    ".github/workflows/pr_review_plan_comment.yml",
+    ".github/workflows/repository_hygiene.yml",
+    "CONTEXT.md",
+    "docs/AI_CODING_GUIDE.md",
+    "docs/maintenance/ai_review_prompts.md",
+    "docs/maintenance/docs_warning_triage.md",
+    "docs/maintenance/index.md",
+    "docs/maintenance/maintainer_sop.md",
+    "docs/maintenance/pr_review_plan.md",
+    "docs/maintenance/risk_map.md",
+    "docs/maintenance/review_workflow.md",
+    "docs/maintenance/test_strategy.md",
+    "docs/adr/index.md",
+)
+
+REQUIRED_DOCS_INDEX_ENTRIES = (
+    "maintenance/index",
+)
+
+REQUIRED_MAINTENANCE_INDEX_ENTRIES = (
+    "ai_review_prompts",
+    "docs_warning_triage",
+    "maintainer_sop",
+    "pr_review_plan",
+    "test_strategy",
+)
+
+
+def check_examples_json() -> list[str]:
+    errors: list[str] = []
+    json_files = sorted((REPO_ROOT / "examples").rglob("*.json"))
+
+    for path in json_files:
+        try:
+            json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:  # noqa: BLE001 - report any parser/read failure.
+            rel_path = path.relative_to(REPO_ROOT)
+            errors.append(f"{rel_path}: invalid JSON ({type(exc).__name__}: {exc})")
+
+    print(f"Checked {len(json_files)} example JSON files.")
+    return errors
+
+
+def check_required_files() -> list[str]:
+    errors: list[str] = []
+
+    for rel_path in REQUIRED_FILES:
+        path = REPO_ROOT / rel_path
+        if not path.is_file():
+            errors.append(f"{rel_path}: required maintenance file is missing")
+
+    print(f"Checked {len(REQUIRED_FILES)} required maintenance files.")
+    return errors
+
+
+def check_docs_index() -> list[str]:
+    errors: list[str] = []
+    index_path = REPO_ROOT / "docs/index.rst"
+
+    if not index_path.is_file():
+        return ["docs/index.rst: required docs index is missing"]
+
+    content = index_path.read_text(encoding="utf-8")
+    for entry in REQUIRED_DOCS_INDEX_ENTRIES:
+        if entry not in content:
+            errors.append(f"docs/index.rst: missing toctree entry '{entry}'")
+
+    print(f"Checked docs/index.rst for {len(REQUIRED_DOCS_INDEX_ENTRIES)} required entries.")
+    return errors
+
+
+def check_maintenance_index() -> list[str]:
+    errors: list[str] = []
+    index_path = REPO_ROOT / "docs/maintenance/index.md"
+
+    if not index_path.is_file():
+        return ["docs/maintenance/index.md: required maintenance index is missing"]
+
+    content = index_path.read_text(encoding="utf-8")
+    for entry in REQUIRED_MAINTENANCE_INDEX_ENTRIES:
+        if entry not in content:
+            errors.append(f"docs/maintenance/index.md: missing toctree entry '{entry}'")
+
+    print(
+        "Checked docs/maintenance/index.md for "
+        f"{len(REQUIRED_MAINTENANCE_INDEX_ENTRIES)} required entries."
+    )
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    errors.extend(check_examples_json())
+    errors.extend(check_required_files())
+    errors.extend(check_docs_index())
+    errors.extend(check_maintenance_index())
+
+    if errors:
+        print("\nRepository hygiene check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print("Repository hygiene check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/pr_review_plan.py
+++ b/scripts/ci/pr_review_plan.py
@@ -226,7 +226,7 @@ def suggested_checks(risk: Risk, paths: list[str]) -> list[str]:
     if touches_docs_or_examples:
         checks.append("python scripts/ci/check_repository_hygiene.py")
     if touches_docs:
-        checks.append("uv run python -m sphinx -b html docs /private/tmp/deeptb-docs-check")
+        checks.append("uv run python -m sphinx -b html docs docs/_build/pr-review-plan-html")
 
     if risk == Risk.HIGH:
         checks.append("uv run pytest ./dptb/tests -m regression")

--- a/scripts/ci/pr_review_plan.py
+++ b/scripts/ci/pr_review_plan.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Generate an advisory DeePTB PR review plan from changed files."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from enum import IntEnum
+
+
+class Risk(IntEnum):
+    LOW = 1
+    MEDIUM = 2
+    HIGH = 3
+
+
+RISK_LABELS = {
+    Risk.LOW: "Low",
+    Risk.MEDIUM: "Medium",
+    Risk.HIGH: "High",
+}
+
+
+@dataclass(frozen=True)
+class AreaRule:
+    name: str
+    risk: Risk
+    focus: str
+    exact: tuple[str, ...] = ()
+    prefixes: tuple[str, ...] = ()
+
+
+AREA_RULES = (
+    AreaRule(
+        name="AtomicDataDict contract",
+        risk=Risk.HIGH,
+        exact=("dptb/data/_keys.py",),
+        focus="key names, key meaning, tensor shape, and downstream callers",
+    ),
+    AreaRule(
+        name="Orbital indexing",
+        risk=Risk.HIGH,
+        exact=("dptb/data/transforms.py",),
+        focus="basis ordering, orbital block indices, and mixed-basis behavior",
+    ),
+    AreaRule(
+        name="Hamiltonian expansion",
+        risk=Risk.HIGH,
+        exact=("dptb/nn/hamiltonian.py",),
+        focus="SK/E3 transforms, signs, ordering, dtype/device, and overlap",
+    ),
+    AreaRule(
+        name="Model assembly",
+        risk=Risk.HIGH,
+        exact=("dptb/nn/build.py",),
+        focus="model type detection, checkpoint loading, and config interpretation",
+    ),
+    AreaRule(
+        name="Config schema",
+        risk=Risk.HIGH,
+        exact=("dptb/utils/argcheck.py",),
+        focus="defaults, backward compatibility, docs/examples alignment",
+    ),
+    AreaRule(
+        name="Training behavior",
+        risk=Risk.HIGH,
+        exact=("dptb/nnops/trainer.py",),
+        focus="task detection, validation behavior, and reference datasets",
+    ),
+    AreaRule(
+        name="Loss behavior",
+        risk=Risk.HIGH,
+        exact=("dptb/nnops/loss.py",),
+        focus="numerical targets, masks, reductions, and task-specific semantics",
+    ),
+    AreaRule(
+        name="Embedding and prediction",
+        risk=Risk.MEDIUM,
+        prefixes=("dptb/nn/embedding/", "dptb/nn/prediction/"),
+        focus="tensor shape, irreps, batch behavior, and model compatibility",
+    ),
+    AreaRule(
+        name="Dataset backends",
+        risk=Risk.MEDIUM,
+        prefixes=("dptb/data/",),
+        focus="format compatibility, missing fields, and cutoff behavior",
+    ),
+    AreaRule(
+        name="CLI entrypoints",
+        risk=Risk.MEDIUM,
+        prefixes=("dptb/entrypoints/",),
+        focus="args, defaults, config loading, and user-facing behavior",
+    ),
+    AreaRule(
+        name="Postprocess and export",
+        risk=Risk.MEDIUM,
+        prefixes=("dptb/postprocess/",),
+        focus="exported formats, unit conventions, and compatibility",
+    ),
+    AreaRule(
+        name="Plugins",
+        risk=Risk.MEDIUM,
+        prefixes=("dptb/plugins/",),
+        focus="checkpointing, logging, and training lifecycle",
+    ),
+    AreaRule(
+        name="GitHub Actions and CI",
+        risk=Risk.MEDIUM,
+        prefixes=(".github/workflows/",),
+        focus="trigger scope, required checks, dependency installation, and runtime noise",
+    ),
+    AreaRule(
+        name="Tests",
+        risk=Risk.MEDIUM,
+        prefixes=("dptb/tests/",),
+        focus="marker choice, regression coverage, skipped environments, and assertions",
+    ),
+    AreaRule(
+        name="Examples and configs",
+        risk=Risk.LOW,
+        prefixes=("examples/",),
+        focus="valid JSON, command consistency, and config/schema compatibility",
+    ),
+    AreaRule(
+        name="Documentation",
+        risk=Risk.LOW,
+        prefixes=("docs/",),
+        exact=("README.md",),
+        focus="stale commands, stale paths, config consistency, and Sphinx warnings",
+    ),
+    AreaRule(
+        name="Issue templates",
+        risk=Risk.LOW,
+        prefixes=(".github/ISSUE_TEMPLATE/",),
+        focus="clarity and triage usefulness",
+    ),
+    AreaRule(
+        name="Packaging metadata",
+        risk=Risk.LOW,
+        exact=("pyproject.toml", ".github/release-check.md"),
+        focus="dependency compatibility and install behavior",
+    ),
+    AreaRule(
+        name="Maintenance governance",
+        risk=Risk.LOW,
+        exact=("CONTEXT.md",),
+        prefixes=("docs/maintenance/", "docs/adr/", "scripts/ci/"),
+        focus="review guidance consistency and low-noise maintainer workflow",
+    ),
+)
+
+
+def normalize_path(path: str) -> str:
+    path = path.strip().replace("\\", "/")
+    while path.startswith("./"):
+        path = path[2:]
+    return path
+
+
+def collect_paths(args: argparse.Namespace) -> list[str]:
+    paths: list[str] = []
+    if args.stdin:
+        paths.extend(sys.stdin.read().splitlines())
+    paths.extend(args.changed_files or [])
+
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for path in paths:
+        clean = normalize_path(path)
+        if clean and clean not in seen:
+            seen.add(clean)
+            normalized.append(clean)
+    return normalized
+
+
+def matches_rule(path: str, rule: AreaRule) -> bool:
+    return path in rule.exact or any(path.startswith(prefix) for prefix in rule.prefixes)
+
+
+def classify(paths: list[str]) -> tuple[Risk, list[tuple[AreaRule, list[str]]], list[str]]:
+    rule_files: dict[AreaRule, list[str]] = {rule: [] for rule in AREA_RULES}
+
+    for path in paths:
+        path_rules = [rule for rule in AREA_RULES if matches_rule(path, rule)]
+        if not path_rules:
+            continue
+        max_risk = max(rule.risk for rule in path_rules)
+        for rule in path_rules:
+            if rule.risk == max_risk:
+                rule_files[rule].append(path)
+
+    matched: list[tuple[AreaRule, list[str]]] = []
+    for rule in AREA_RULES:
+        files = rule_files[rule]
+        if files:
+            matched.append((rule, files))
+
+    matched_paths = {path for _, files in matched for path in files}
+    unmatched = [path for path in paths if path not in matched_paths]
+
+    risk = max((rule.risk for rule, _ in matched), default=Risk.LOW)
+
+    touches_data = any(path.startswith("dptb/data/") for path in paths)
+    touches_model = any(path.startswith(("dptb/nn/", "dptb/nnops/")) for path in paths)
+    if touches_data and touches_model:
+        risk = Risk.HIGH
+
+    return risk, matched, unmatched
+
+
+def has_any(paths: list[str], prefixes: tuple[str, ...] = (), exact: tuple[str, ...] = ()) -> bool:
+    return any(path in exact or any(path.startswith(prefix) for prefix in prefixes) for path in paths)
+
+
+def suggested_checks(risk: Risk, paths: list[str]) -> list[str]:
+    checks: list[str] = []
+    touches_docs_or_examples = has_any(
+        paths,
+        prefixes=("docs/", "examples/", ".github/workflows/", "scripts/ci/"),
+        exact=("CONTEXT.md", ".github/pull_request_template.md"),
+    )
+    touches_docs = has_any(paths, prefixes=("docs/",), exact=("README.md",))
+    touches_behavior = has_any(paths, prefixes=("dptb/",), exact=("pyproject.toml",))
+
+    if touches_docs_or_examples:
+        checks.append("python scripts/ci/check_repository_hygiene.py")
+    if touches_docs:
+        checks.append("uv run python -m sphinx -b html docs /private/tmp/deeptb-docs-check")
+
+    if risk == Risk.HIGH:
+        checks.append("uv run pytest ./dptb/tests -m regression")
+        checks.append("uv run pytest ./dptb/tests")
+    elif risk == Risk.MEDIUM:
+        checks.append("uv run pytest ./dptb/tests -m smoke")
+        if touches_behavior:
+            checks.append("uv run pytest ./dptb/tests -m regression")
+        else:
+            checks.append('uv run pytest ./dptb/tests -m "not slow"')
+    else:
+        if touches_behavior:
+            checks.append("uv run pytest ./dptb/tests -m smoke")
+
+    if not checks:
+        checks.append("uv run pytest ./dptb/tests -m smoke")
+
+    deduped: list[str] = []
+    for check in checks:
+        if check not in deduped:
+            deduped.append(check)
+    return deduped
+
+
+def ai_prompt_suggestions(risk: Risk) -> list[str]:
+    if risk == Risk.LOW:
+        return [
+            "Optional: run the Test Gap Review Prompt if examples, docs commands, or test markers changed.",
+        ]
+    return [
+        "Run the Maintainer Review Prompt from docs/maintenance/ai_review_prompts.md.",
+        "Run the Test Gap Review Prompt from docs/maintenance/ai_review_prompts.md.",
+    ]
+
+
+def maintainer_focus(risk: Risk, matched: list[tuple[AreaRule, list[str]]], paths: list[str]) -> list[str]:
+    focus = [f"{rule.name}: {rule.focus}" for rule, _ in matched]
+    if any(path.startswith("dptb/data/") for path in paths) and any(
+        path.startswith(("dptb/nn/", "dptb/nnops/")) for path in paths
+    ):
+        focus.append("Cross-boundary risk: data representation and model/training behavior changed together.")
+    if risk == Risk.HIGH:
+        focus.append("Confirm compatibility for public API, CLI/config schema, checkpoints, and datasets.")
+    if not focus:
+        focus.append("Confirm the PR scope is clear and no unrelated cleanup is mixed in.")
+    return focus
+
+
+def hold_conditions(risk: Risk) -> list[str]:
+    holds = [
+        "CI failed and the failure is not explained.",
+        "The PR scope is unclear or mixes unrelated changes.",
+    ]
+    if risk >= Risk.MEDIUM:
+        holds.append("AI review found a plausible correctness issue that was not fixed or explicitly waived.")
+    if risk == Risk.HIGH:
+        holds.extend(
+            [
+                "High-risk behavior changed without a regression test or documented waiver.",
+                "Config, checkpoint, dataset, tensor key/order, or numerical compatibility is unclear.",
+            ]
+        )
+    return holds
+
+
+def render_plan(paths: list[str]) -> str:
+    risk, matched, unmatched = classify(paths)
+    lines: list[str] = [
+        "# DeePTB PR Review Plan",
+        "",
+        f"Risk level: **{RISK_LABELS[risk]}**",
+        f"Changed files: **{len(paths)}**",
+        "",
+        "## Touched Risk Areas",
+    ]
+
+    if matched:
+        for rule, files in matched:
+            preview = ", ".join(files[:5])
+            suffix = "" if len(files) <= 5 else f", ... ({len(files)} files)"
+            lines.append(f"- **{rule.name}** ({RISK_LABELS[rule.risk]}): {preview}{suffix}")
+    else:
+        lines.append("- No mapped DeePTB risk area matched. Review scope manually.")
+
+    if unmatched:
+        preview = ", ".join(unmatched[:8])
+        suffix = "" if len(unmatched) <= 8 else f", ... ({len(unmatched)} files)"
+        lines.append(f"- **Unmapped files**: {preview}{suffix}")
+
+    sections = (
+        ("Required Maintainer Focus", maintainer_focus(risk, matched, paths)),
+        ("Suggested AI Review", ai_prompt_suggestions(risk)),
+        ("Suggested Checks", suggested_checks(risk, paths)),
+        ("Hold Conditions To Check", hold_conditions(risk)),
+    )
+    for title, items in sections:
+        lines.extend(["", f"## {title}"])
+        lines.extend(f"- {item}" for item in items)
+
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "- This plan is advisory and does not replace maintainer judgment.",
+            "- Use the higher risk level when the PR body and changed files disagree.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate an advisory DeePTB PR review plan from changed files."
+    )
+    parser.add_argument(
+        "--changed-files",
+        nargs="*",
+        default=[],
+        help="Changed files to classify. May be combined with --stdin.",
+    )
+    parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read newline-separated changed files from stdin.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    paths = collect_paths(args)
+    if not paths:
+        print(
+            "No changed files provided. Use --changed-files <path...> or pipe paths with --stdin.",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(render_plan(paths), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds lightweight governance and review safeguards for DeePTB to reduce single-maintainer review risk and make AI-assisted coding easier to review safely.

Key additions:
- maintainer context, risk map, review SOP, AI review prompts, ADR entry points, and PR checklist;
- repository hygiene checks for example JSON, maintenance docs, and docs navigation;
- pytest markers for `smoke`, `regression`, and `slow` test layering;
- advisory PR review plan script plus GitHub Actions summary/comment workflows;
- issue template fields that collect risk, compatibility, reproduction, and test information earlier;
- docs warning triage and low-risk docs navigation/image/title cleanup.

## Developer Impact

Maintainers can now run:

```bash
python scripts/ci/check_repository_hygiene.py
git diff --name-only main...HEAD | python scripts/ci/pr_review_plan.py --stdin
uv run pytest ./dptb/tests -m smoke
uv run pytest ./dptb/tests -m regression
uv run pytest ./dptb/tests -m "not slow"
```

Fork PRs can receive an advisory PR review plan comment via `pull_request_target` without executing fork code; the workflow reads changed file names through the GitHub API and runs trusted base-branch code.

## Validation

- `python3 scripts/ci/check_repository_hygiene.py`
- `uv run pytest ./dptb/tests --collect-only -m smoke`
- `uv run pytest ./dptb/tests --collect-only -m regression`
- `uv run pytest ./dptb/tests --collect-only -m slow`
- `uv run pytest ./dptb/tests -m smoke`
- `uv run python -m sphinx -b html docs /private/tmp/deeptb-docs-check`

Sphinx build succeeds with 41 known warnings, recorded in `docs/maintenance/docs_warning_triage.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ADRs, maintainer SOP, PR review plan, risk map, test strategy, AI coding guide, review prompts, and several doc/index updates.

* **Chores**
  * Expanded and standardized issue & PR templates.
  * Added automated PR review-plan and repository-hygiene workflows and supporting tooling.
  * Added a repository hygiene check utility.

* **Tests**
  * Introduced pytest markers (smoke, regression, slow) and configured marker descriptions; applied markers across test modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepmodeling/DeePTB/pull/337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->