### PR TITLE
CI: keep PR review plan comment checkout in sync

### DIFF
--- a/.github/workflows/pr_review_plan_comment.yml
+++ b/.github/workflows/pr_review_plan_comment.yml
@@ -16,7 +16,8 @@ jobs:
       - name: Checkout trusted base code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          # Keep the workflow and helper script versions in sync while avoiding fork code.
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

- fix the PR review plan comment workflow for older open PRs whose base SHA predates the latest helper script
- checkout the trusted base branch ref instead of the old pull request base SHA
- keep fork safety: the workflow still does not checkout or execute fork code

## Root Cause

For PR #330, the workflow file from current main invoked `pr_review_plan.py --format github-comment`, but the job checked out `github.event.pull_request.base.sha`, which pointed at an older main commit that did not support that flag. The script exited with code 2 before updating the comment.

## Validation

- `ruby -e 'require yaml; YAML.load_file(.github/workflows/pr_review_plan_comment.yml)'`
- `python3 scripts/ci/check_repository_hygiene.py`
- Simulated PR #330 changed-file input through `python3 scripts/ci/pr_review_plan.py --stdin --format github-comment`
